### PR TITLE
Fixup for second order path planner bug

### DIFF
--- a/abr_control/controllers/path_planners/second_order.py
+++ b/abr_control/controllers/path_planners/second_order.py
@@ -1,4 +1,6 @@
 import numpy as np
+import matplotlib
+matplotlib.use("TKAgg")
 
 from .path_planner import PathPlanner
 
@@ -12,90 +14,94 @@ class SecondOrder(PathPlanner):
     Implements the second order filter from
     www.mathworks.com/help/physmod/sps/powersys/ref/secondorderfilter.html
 
+    returns the next state in the path in the form
+    np.hstack([posx, posy, posz, velx, vely, velz])
+
     Parameters
     ----------
     robot_config : class instance
         passes in all relevant information about the arm
         from its config, such as: number of joints, number
         of links, mass information etc.
+    n_timesteps : int, optional (Default: 100)
+        the number of time steps to reach the target
+    dt : float, optional (Default: 0.001)
+        the loop speed [seconds]
+    zeta  float, optional (Default: 2.0)
+        the damping ratio
+    w : float, optional (Default: 1e-4)
+        the natural frequency
     """
 
-    def __init__(self, robot_config):
+    def __init__(self, robot_config, n_timesteps=100, dt=0.001, zeta=2.0,
+                 w=1e4):
         super(SecondOrder, self).__init__(robot_config)
+        self.n_timesteps = n_timesteps
+        self.dt = dt
+        self.zeta = zeta
+        self.w = w/n_timesteps # gain to converge in the desired time
 
-    def step(self, y, dy, target, w, zeta):
+    def step(self, state, target):
         """ Calculates the next state given the current state and
         system dynamics' parameters.
 
         Parameters
         ----------
-        y : numpy.array
-            the current position of the system
-        dy : numpy.array
-            the current velocity of the system
+        state : numpy.array
+            the current position and velocity of the system
+            use the format state=np.array([posx, posy, posz, velx, vely, velz])
         target : numpy.array
             the target position of the system
-        w : float
-            the natural frequency
-        zeta : float
-            the damping ratio
         """
-        ddy = w**2 * target - dy * zeta * w - y * w**2
-        return dy, ddy
+        y = state[:3]
+        dy = state[3:]
+        ddy = self.w**2 * target - dy * self.zeta * self.w - y * self.w**2
+        state += np.hstack((dy, ddy)) * self.dt
+        return state
 
-    def generate_path(self, state, target, n_timesteps=100,
-                      plot=False, zeta=2.0, dt=0.001):
+    def generate_path(self, state, target, plot=False):
         """ Filter the target so that it doesn't jump, but moves smoothly
 
         Parameters
         ----------
         state : numpy.array
-            the current position of the system
+            the current position and velocity of the system
+            use the format state=np.array([posx, posy, posz, velx, vely, velz])
         target : numpy.array
             the target state
-        n_timesteps : int, optional (Default: 100)
-            the number of time steps to reach the target
-        zeta  float, optional (Default: 2.0)
-            the damping ratio
         plot: boolean, optional (Default: False)
             plot the path after generating if True
         """
 
-        n_states = len(state)
-
-        w = 1e4 / n_timesteps # gain to converge in the desired time
+        n_states = int(len(state)/2)
 
         self.trajectory = []
-        y = np.hstack([state, np.zeros(n_states)])
-        for ii in range(n_timesteps):
-            self.trajectory.append(np.copy(y))
-            y += np.hstack(self.step(
-                y[:n_states], y[n_states:], target, w, zeta)
-                ) * dt
+        for ii in range(self.n_timesteps):
+            self.trajectory.append(np.copy(state))
+            state = self.step(state=state, target=target)
         self.trajectory = np.array(self.trajectory)
 
         # reset trajectory index
         self.n = 0
-        self.n_timesteps = n_timesteps
 
         if plot:
             import matplotlib.pyplot as plt
             plt.figure()
             plt.subplot(2, 1, 1)
-            plt.plot(np.ones((n_timesteps, n_states)) *
-                              np.arange(n_timesteps)[:, None],
+            plt.plot(np.ones((self.n_timesteps, n_states)) *
+                              np.arange(self.n_timesteps)[:, None],
                      self.trajectory[:, :n_states])
             plt.gca().set_prop_cycle(None)
-            plt.plot(np.ones((n_timesteps, n_states)) *
-                              np.arange(n_timesteps)[:, None],
-                     np.ones((n_timesteps, n_states)) * target, '--')
+            plt.plot(np.ones((self.n_timesteps, n_states)) *
+                              np.arange(self.n_timesteps)[:, None],
+                     np.ones((self.n_timesteps, n_states)) * target, '--')
             plt.legend(['%i' % ii for ii in range(n_states)] +
                        ['%i_target' % ii for ii in range(n_states)])
             plt.title('Trajectory positions')
 
             plt.subplot(2, 1, 2)
-            plt.plot(np.ones((n_timesteps, n_states)) *
-                              np.arange(n_timesteps)[:, None],
+            plt.plot(np.ones((self.n_timesteps, n_states)) *
+                              np.arange(self.n_timesteps)[:, None],
                      self.trajectory[:, n_states:])
             plt.legend(['d%i' % ii for ii in range(n_states)])
             plt.title('Trajectory velocities')

--- a/examples/PyGame/path_planning_second_order.py
+++ b/examples/PyGame/path_planning_second_order.py
@@ -25,7 +25,7 @@ ctrlr = OSC(robot_config, kp=200, vmax=10)
 # create our path planner
 n_timesteps = 250
 # NOTE: delete above n_timesteps if it can be used in this example
-path_planner = path_planners.SecondOrder(robot_config)
+path_planner = path_planners.SecondOrder(robot_config, n_timesteps=n_timesteps)
 
 # create our interface
 interface = PyGame(robot_config, arm_sim, dt=.001)
@@ -44,6 +44,7 @@ try:
 
         if count % n_timesteps == 0:
         #  if count == 0:
+            state = np.hstack((hand_xyz, np.zeros(3)))
             target_xyz = np.array([
                 np.random.random() * 2 - 1,
                 np.random.random() * 2 + 1,
@@ -51,8 +52,8 @@ try:
             # update the position of the target
             interface.set_target(target_xyz)
             path_planner.generate_path(
-                state=hand_xyz, target=target_xyz,
-                n_timesteps=n_timesteps, plot=True)
+                state=state, target=target_xyz,
+                plot=True)
 
         # returns desired [position, velocity]
         target = path_planner.next_target()


### PR DESCRIPTION
- both step and generate functions return the state in the form
  np.hstack([posx, posy, posz, velx, vely, velz]) and expect an input state in
  the same form
- most parameters moved to init, now to generate and step you only need to pass
  in the state and target, the rest is passed in during initialization