### PR TITLE
Dynadapt sampling fix

### DIFF
--- a/abr_control/controllers/path_planners/orientation.py
+++ b/abr_control/controllers/path_planners/orientation.py
@@ -63,6 +63,9 @@ class Orientation():
                 quat, axes='rxyz')
 
         self.n = 0
+        if plot:
+            self._plot()
+
         return self.orientation
 
 
@@ -95,7 +98,7 @@ class Orientation():
         return orientation
 
 
-    def plot(self):
+    def _plot(self):
         """ Plot the generated trajectory
         """
         plt.figure()

--- a/abr_control/controllers/path_planners/path_planner.py
+++ b/abr_control/controllers/path_planners/path_planner.py
@@ -70,11 +70,11 @@ class PathPlanner:
         error = 1 - error
 
         orientation_path_planner = Orientation(timesteps=error)
-        orientation_path_planner.generate_path(
+        orientation_path = orientation_path_planner.generate_path(
             orientation=orientation, target_orientation=target_orientation,
             plot=plot)
 
-        return orientation_path_planner
+        return orientation_path, orientation_path_planner
 
 
     #NOTE: do we need this check? should it be in the generate_path func?

--- a/abr_control/controllers/path_planners/second_order.py
+++ b/abr_control/controllers/path_planners/second_order.py
@@ -55,8 +55,7 @@ class SecondOrder(PathPlanner):
         self.threshold = threshold
 
 
-    def generate_path(self, position, velocity, target_pos, plot=False,
-                      **kwargs):
+    def generate_path(self, position, velocity, target_pos, plot=False):
         """
         Calls the step function self.n_timestep times to pregenerate
         the entire path planner

--- a/abr_control/controllers/path_planners/second_order_bell_shaped.py
+++ b/abr_control/controllers/path_planners/second_order_bell_shaped.py
@@ -58,7 +58,7 @@ class BellShaped(PathPlanner):
         self.dmps.imitate_path(y_des)
 
 
-    def generate_path(self, position, target_pos, plot=False, **kwargs):
+    def generate_path(self, position, target_pos, plot=False):
         """
         Calls the step function self.n_timestep times to pregenerate
         the entire path planner

--- a/abr_control/controllers/signals/tests/test_dynamics_adaptation.py
+++ b/abr_control/controllers/signals/tests/test_dynamics_adaptation.py
@@ -3,7 +3,9 @@ import pytest
 import numpy as np
 
 from abr_control.arms import ur5
+from abr_control.controllers import signals
 from abr_control.controllers.signals import DynamicsAdaptation
+from nengolib.stats import ScatteredHypersphere
 
 def test_scaling():
     robot_config = ur5.Config(use_cython=True)
@@ -39,3 +41,87 @@ def test_scaling():
         unscaled = np.random.random(robot_config.N_JOINTS) * 50 + 25
         scaled = adapt.scale_inputs(unscaled)
         assert np.linalg.norm(scaled) - 1 < 1e-5
+
+@pytest.mark.parametrize('spherical', ((True), (False)))
+@pytest.mark.parametrize('intercepts_bounds, intercepts_mode', (
+    ([-0.4, -0.2], -0.3), (None, None)))
+@pytest.mark.parametrize('n_neurons', ((1000), (100)))
+@pytest.mark.parametrize('n_ensembles', ((1), (4)))
+@pytest.mark.parametrize('intercepts', (('manual'), (None)))
+@pytest.mark.parametrize('encoders', (('manual'), (None)))
+
+
+def test_intercepts_and_encoders(
+        spherical, intercepts_bounds, intercepts_mode, n_neurons, n_ensembles,
+        intercepts, encoders):
+
+    n_input = 2
+    n_output = 3
+    seed = 0
+
+    if encoders == 'manual':
+        # reset rng
+        np.random.seed = seed
+
+        hypersphere = ScatteredHypersphere(surface=True)
+        encoders = hypersphere.sample(
+            n_neurons * n_ensembles, n_input + spherical)
+
+        encoders = encoders.reshape(
+            n_ensembles, n_neurons, n_input + spherical)
+
+    if intercepts == 'manual':
+        # reset rng
+        np.random.seed = seed
+
+        intercepts = (
+            signals.dynamics_adaptation.AreaIntercepts(
+                dimensions=n_input + spherical,
+                base=signals.dynamics_adaptation.Triangular(
+                    -0.4, -0.3, -0.2)))
+
+        intercepts = np.array(intercepts.sample(
+            n_neurons * n_ensembles))
+
+        intercepts = intercepts.reshape(
+            n_ensembles, n_neurons)
+
+    adapt = DynamicsAdaptation(
+        n_input=n_input,
+        n_output=n_output,
+        n_neurons=n_neurons,
+        n_ensembles=n_ensembles,
+        seed=seed,
+        intercepts_bounds=intercepts_bounds,
+        intercepts_mode=intercepts_mode,
+        encoders=encoders,
+        intercepts=intercepts,
+        spherical=spherical)
+
+    for ii in range(n_ensembles):
+        enc_shape = adapt.sim.data[adapt.adapt_ens[ii]].encoders.shape
+        assert np.array_equal(
+            np.asarray(enc_shape), np.array([n_neurons, n_input + spherical]))
+
+        int_shape = adapt.sim.data[adapt.adapt_ens[ii]].intercepts.shape
+        assert np.array_equal(
+            np.asarray(int_shape), np.array([n_neurons, ]))
+
+    # check that our intercepts and encoders are the same to confirm the seed
+    # has not changed
+    adapt2 = DynamicsAdaptation(
+        n_input=n_input,
+        n_output=n_output,
+        n_neurons=n_neurons,
+        n_ensembles=n_ensembles,
+        seed=seed,
+        intercepts_bounds=intercepts_bounds,
+        intercepts_mode=intercepts_mode,
+        encoders=encoders,
+        intercepts=intercepts,
+        spherical=spherical)
+
+    enc2_shape = adapt2.sim.data[adapt2.adapt_ens[ii]].encoders.shape
+    int2_shape = adapt2.sim.data[adapt2.adapt_ens[ii]].intercepts.shape
+    assert np.array_equal(enc2_shape, enc_shape)
+    assert np.array_equal(int2_shape, int_shape)

--- a/examples/VREP/path_planner_bell_shaped.py
+++ b/examples/VREP/path_planner_bell_shaped.py
@@ -51,7 +51,7 @@ target_position = [-0.4, -0.3, 0.6]
 
 traj_planner.generate_path(
     position=hand_xyz, target_pos=target_position, n_timesteps=n_timesteps)
-orientation_planner = traj_planner.generate_orientation_path(
+_, orientation_planner = traj_planner.generate_orientation_path(
     orientation=starting_orientation, target_orientation=target_orientation)
 
 # set up lists for tracking data


### PR DESCRIPTION
- `path_planner.generate_orientation_path()` returns both path planner object and generated path
   - need object if stepping through path, need path itself if doing time based path planning
- fixed dynadapt bug with sampling intercepts and encoders