### PR TITLE
Removed python version limit

### DIFF
--- a/.ci/static.sh
+++ b/.ci/static.sh
@@ -13,10 +13,10 @@ COMMAND=$1
 
 if [[ "$COMMAND" == "install" ]]; then
     # astroid==2.2 causes an error when running pylint
-    exe pip install codespell pylint gitlint "astroid<2.2.0"
+    exe pip install codespell pylint gitlint "astroid"
 elif [[ "$COMMAND" == "script" ]]; then
     exe pylint abr_control --rcfile=setup.cfg --ignore=arm_files,vrep_files
-    exe codespell -q 3 --skip=arm_files,vrep_files
+    exe codespell -q 3 --skip=arm_files,vrep_files --ignore-words-list="DOF,dof"
     exe shellcheck -e SC2087 .ci/*.sh
     # undo single-branch cloning
     git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*

--- a/abr_control/__init__.py
+++ b/abr_control/__init__.py
@@ -1,14 +1,3 @@
 from .version import version as __version__
 
 from . import controllers
-
-import sys
-if sys.version_info > (3, 6, 9):
-    raise ImportError(
-        """
-You are using Python version %s and abr_control
-currently supports python up to 3.6.9.
-
-Please create a new environment with python =<3.6.9
-"""
-% (sys.version))

--- a/abr_control/arms/jaco2/config.py
+++ b/abr_control/arms/jaco2/config.py
@@ -17,9 +17,8 @@ class Config(BaseConfig):
 
     Attributes
     ----------
-    REST_ANGLES : numpy.array
-        the joint angles the arm tries to push towards with the
-        null controller
+    START_ANGLES : numpy.array
+        The joint angles for a safe home or rest position
     _M_LINKS : sympy.diag
         inertia matrix of the links
     _M_JOINTS : sympy.diag
@@ -52,8 +51,6 @@ class Config(BaseConfig):
         abr_control.utils.os_utils.makedirs(self.config_folder)
 
         self.JOINT_NAMES = ['joint%i' % ii for ii in range(self.N_JOINTS)]
-
-        self.REST_ANGLES = np.array([None, 2.42, 2.42, 0.0, 0.0, 0.0])
 
         # position to move to before switching to torque mode
         self.START_ANGLES = np.array(

--- a/abr_control/arms/onejoint/config.py
+++ b/abr_control/arms/onejoint/config.py
@@ -9,9 +9,8 @@ class Config(BaseConfig):
 
     Attributes
     ----------
-    REST_ANGLES : numpy.array
-        the joint angles the arm tries to push towards with the
-        null controller
+    START_ANGLES : numpy.array
+        The joint angles for a safe home or rest position
     _M_LINKS : sympy.diag
         inertia matrix of the links
     _M_JOINTS : sympy.diag
@@ -36,7 +35,7 @@ class Config(BaseConfig):
         self._T = {}  # dictionary for storing calculated transforms
 
         self.JOINT_NAMES = ['joint0']
-        self.REST_ANGLES = np.array([np.pi/2.0])
+        self.START_ANGLES = np.array([np.pi/2.0])
 
         # create the inertia matrices for each link
         self._M_LINKS.append(np.diag([1.0, 1.0, 1.0,

--- a/abr_control/arms/threejoint/arm_sim.py
+++ b/abr_control/arms/threejoint/arm_sim.py
@@ -16,7 +16,7 @@ class ArmSim():
         such as: number of joints, number of links, mass information etc.
     dt: float, optional (Default: 0.001)
         simulation time step [seconds]
-    q_init : numpy.array, optional (Default: robot_config.REST_ANGLES)
+    q_init : numpy.array, optional (Default: robot_config.START_ANGLES)
         start joint angles [radians]
     dq_init : numpy.array, optional (Default: np.zeros)
         start joint velocity [radians/second]
@@ -32,7 +32,7 @@ class ArmSim():
 
         self.init_state = np.zeros(self.robot_config.N_JOINTS*2)
         if q_init is None:
-            self.init_state[::2] = self.robot_config.REST_ANGLES
+            self.init_state[::2] = self.robot_config.START_ANGLES
         else:
             self.init_state[::2] = q_init
         if dq_init is not None:

--- a/abr_control/arms/threejoint/config.py
+++ b/abr_control/arms/threejoint/config.py
@@ -9,9 +9,8 @@ class Config(BaseConfig):
 
     Attributes
     ----------
-    REST_ANGLES : numpy.array
-        the joint angles the arm tries to push towards with the
-        null controller
+    START_ANGLES : numpy.array
+        The joint angles for a safe home or rest position
     _M_LINKS : sympy.diag
         inertia matrix of the links
     _M_JOINTS : sympy.diag
@@ -38,8 +37,8 @@ class Config(BaseConfig):
         self._T = {}  # dictionary for storing calculated transforms
 
         # for the null space controller, keep arm near these angles
-        self.REST_ANGLES = np.array([np.pi/4.0, np.pi/4.0, np.pi/4.0],
-                                    dtype='float32')
+        self.START_ANGLES = np.array([np.pi/4.0, np.pi/4.0, np.pi/4.0],
+                                     dtype='float32')
 
         # create the inertia matrices for each link of the three joint
         # TODO: identify the actual values for these links

--- a/abr_control/arms/twojoint/arm_sim.py
+++ b/abr_control/arms/twojoint/arm_sim.py
@@ -13,7 +13,7 @@ class ArmSim():
         such as: number of joints, number of links, mass information etc.
     dt: float, optional (Default: 0.001)
         simulation time step [seconds]
-    q_init : numpy.array, optional (Default: robot_config.REST_ANGLES)
+    q_init : numpy.array, optional (Default: robot_config.START_ANGLES)
         start joint angles [radians]
     """
 
@@ -22,7 +22,7 @@ class ArmSim():
         self.robot_config = robot_config
 
         self.q_init = (q_init if q_init is not None else
-                       self.robot_config.REST_ANGLES)
+                       self.robot_config.START_ANGLES)
         self.reset()
 
         M = self.robot_config._M_LINKS

--- a/abr_control/arms/twojoint/config.py
+++ b/abr_control/arms/twojoint/config.py
@@ -9,9 +9,8 @@ class Config(BaseConfig):
 
     Attributes
     ----------
-    REST_ANGLES : numpy.array
-        the joint angles the arm tries to push towards with the
-        null controller
+    START_ANGLES : numpy.array
+        The joint angles for a safe home or rest position
     _M_LINKS : sympy.diag
         inertia matrix of the links
     _M_JOINTS : sympy.diag
@@ -36,7 +35,7 @@ class Config(BaseConfig):
         self._T = {}  # dictionary for storing calculated transforms
 
         # for the null space controller, keep arm near these angles
-        self.REST_ANGLES = np.array([np.pi/4.0, np.pi/4.0])
+        self.START_ANGLES = np.array([np.pi/4.0, np.pi/4.0])
 
         # create the inertia matrices for each link of the twojoint
         self._M_LINKS.append(np.diag(np.zeros(6)))  # non-existent link0

--- a/abr_control/arms/ur5/config.py
+++ b/abr_control/arms/ur5/config.py
@@ -9,9 +9,8 @@ class Config(BaseConfig):
 
     Attributes
     ----------
-    REST_ANGLES : numpy.array
-        the joint angles the arm tries to push towards with the
-        null controller
+    START_ANGLES : numpy.array
+        The joint angles for a safe home or rest position
     _M_LINKS : sympy.diag
         inertia matrix of the links
     _M_JOINTS : sympy.diag
@@ -39,11 +38,6 @@ class Config(BaseConfig):
 
         self.JOINT_NAMES = ['UR5_joint%i' % ii
                             for ii in range(self.N_JOINTS)]
-
-        # for the null space controller, keep arm near these angles
-        self.REST_ANGLES = np.array(
-            [None, np.pi/4.0, -np.pi/2.0, np.pi/4.0, np.pi/2.0, np.pi/2.0],
-            dtype='float32')
 
         self.START_ANGLES = np.array(
             [0, np.pi/4.0, -np.pi/2.0, np.pi/4.0, np.pi/2.0, np.pi/2.0],

--- a/abr_control/controllers/osc.py
+++ b/abr_control/controllers/osc.py
@@ -204,13 +204,9 @@ class OSC(Controller):
         xyz_offset: list, optional (Default: None)
             point of interest inside the frame of reference [meters]
         """
-        assert np.array(target).shape[0] == 6, (
-            "Expect a shape of 6, but received shape %i" % (target.shape[0])
-            + " from target: ", target)
 
         if target_vel is None:
             target_vel = self.ZEROS_SIX
-        assert np.array(target_vel).shape[0] == 6
 
         J = self.robot_config.J(ref_frame, q, x=xyz_offset)  # Jacobian
         # isolate rows of Jacobian corresponding to controlled task space DOF
@@ -248,7 +244,7 @@ class OSC(Controller):
         if np.all(target_vel == 0):
             # if there's no target velocity in task space,
             # compensate for velocity in joint space (more accurate)
-            u = -self.kv * np.dot(M, dq)
+            u = -1 * self.kv * np.dot(M, dq)
         else:
             dx = np.zeros(6)
             dx[self.ctrlr_dof] = np.dot(J, dq)

--- a/abr_control/controllers/path_planners/second_order_bell_shaped.py
+++ b/abr_control/controllers/path_planners/second_order_bell_shaped.py
@@ -19,6 +19,7 @@ time_limit specified in `generate_path_function()`
 
 """
 import numpy as np
+import matplotlib.pyplot as plt
 
 try:
     import pydmps
@@ -85,7 +86,6 @@ class BellShaped(PathPlanner):
         self.n = 0
 
         if plot:
-            import matplotlib.pyplot as plt
             plt.plot(self.position)
             plt.legend(['X', 'Y', 'Z'])
             plt.show()

--- a/abr_control/controllers/signals/dynamics_adaptation.py
+++ b/abr_control/controllers/signals/dynamics_adaptation.py
@@ -3,9 +3,12 @@ import numpy as np
 import scipy.special
 
 import nengo
-from nengolib.stats import spherical_transform
-
-
+try:
+    import nengolib
+    from nengolib.stats import spherical_transform
+except ImportError:
+    print('\nnengolib library required for scattered hypersphere encoders'
+          + ' and spherical transform, pip install nengolib for these features\n')
 
 class DynamicsAdaptation():
     """ An implementation of nonlinear dynamics adaptation using Nengo,
@@ -117,7 +120,6 @@ class DynamicsAdaptation():
             np.random.seed = self.seed
             # if NengoLib is installed, use it to optimize encoder placement
             try:
-                import nengolib
                 encoders_dist = nengolib.stats.ScatteredHypersphere(surface=True)
             except ImportError:
                 encoders_dist = nengo.Default

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ tests_require = [
     "pytest-xdist>=1.26.0",
     "pytest-cov>=2.6.0",
     "coverage>=4.5.0",
-    "nengolib>=0.5.0",]
+    "nengolib>=0.5.2",]
 
 setup(
     name="abr_control",
@@ -60,7 +60,6 @@ setup(
     long_description=read('README.rst'),
     install_requires=setup_requires + install_requires,
     setup_requires=setup_requires,
-    python_requires="<3.7",
     extras_require={"tests": tests_require},
     cmdclass={'build_ext': build_ext},
     ext_modules=[


### PR DESCRIPTION
- no longer need to limit python version due to nengolib / scipy issues
  after nengolib 0.5.2
- robot configs no longer have REST_ANGLES, only using START_ANGLES
- removed some unnecessary assertions that were throwing ci errors in
  osc.py
- fixed bug with astroid version
- removed spell check for DOF,dof