### PR TITLE
Made google_id optional on mujoco xmls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,17 +34,18 @@ jobs:
         server: https://test.pypi.org/legacy/
         user: tbekolay
         password: $PYPI_TOKEN
-        distributions: "sdistbdist_wheel"
+        distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: false
           condition: $TRAVIS_BRANCH =~ ^release-candidate-*
-          condition: $TRAVIS_TAG = ""
       - provider: pypi
         user: tbekolay
         password: $PYPI_TOKEN
-        distributions: "sdistbdist_wheel"
+        distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: true
           condition: $TRAVIS_TAG =~ ^v[0-9]*
 
 before_install:
@@ -65,7 +66,7 @@ before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" < "3.6" ]]; then
         echo "Skipping bones-check because Python $TRAVIS_PYTHON_VERSION < 3.6";
     else
-        bones-check;
+        bones-check --verbose;
     fi
   # display environment info
   - pip freeze

--- a/abr_control/arms/mujoco_config.py
+++ b/abr_control/arms/mujoco_config.py
@@ -65,7 +65,8 @@ class MujocoConfig:
             elif name == "N_GRIPPER_JOINTS":
                 self.N_GRIPPER_JOINTS = int(custom.get("data"))
 
-        # get the location of our mesh files
+        # check for google_id specifying download location of robot mesh files
+        self.google_id = None
         for custom in root.findall("custom/text"):
             name = custom.get("name")
             if name == "google_id":
@@ -73,7 +74,7 @@ class MujocoConfig:
 
         # check if the user has downloaded the required mesh files
         # if not prompt them to do so
-        if self.google_id != "None":
+        if self.google_id is not None:
             # get list of expected files to check if all have been downloaded
             files = []
             for asset in root.findall("asset/mesh"):

--- a/abr_control/arms/onejoint/onejoint.xml
+++ b/abr_control/arms/onejoint/onejoint.xml
@@ -2,7 +2,6 @@
 
     <custom>
         <numeric name="START_ANGLES" data="0.0"/>
-        <text name="google_id" data="None"/>
     </custom>
 
     <contact>

--- a/abr_control/arms/threejoint/threejoint.xml
+++ b/abr_control/arms/threejoint/threejoint.xml
@@ -2,7 +2,6 @@
 
     <custom>
         <numeric name="START_ANGLES" data="0.0 0.0 0.0"/>
-        <text name="google_id" data="None"/>
     </custom>
 
     <contact>

--- a/abr_control/arms/twojoint/twojoint.xml
+++ b/abr_control/arms/twojoint/twojoint.xml
@@ -2,7 +2,6 @@
 
     <custom>
         <numeric name="START_ANGLES" data="0.0 0.0"/>
-        <text name="google_id" data="None"/>
     </custom>
 
     <contact>


### PR DESCRIPTION
No longer required to use the `google_id` in the Mujoco robot XML.