### PR TITLE
Updates to path planners

### DIFF
--- a/abr_control/controllers/osc.py
+++ b/abr_control/controllers/osc.py
@@ -6,7 +6,10 @@ from .controller import Controller
 
 
 class OSC(Controller):
-    """ Implements an operational space controller (OSC)
+    """ Implements an operational space controller (OSC). Based on
+    [Khatib, Oussama. "A unified approach for motion and force control of robot
+    manipulators: The operational space formulation." IEEE Journal on Robotics and
+    Automation 3.1 (1987): 43-53.]
 
     Parameters
     ----------

--- a/abr_control/controllers/path_planners/inverse_kinematics.py
+++ b/abr_control/controllers/path_planners/inverse_kinematics.py
@@ -85,10 +85,10 @@ class InverseKinematics:
         q = np.copy(position)
         for ii in range(n_timesteps):
             J = self.robot_config.J("EE", q=q)
-            T = self.robot_config.T("EE", q=q)
-            ee_track.append(T[:3, 3])
+            Tx = self.robot_config.Tx("EE", q=q)
+            ee_track.append(Tx)
 
-            dx = target_position[:3] - T[:3, 3]
+            dx = target_position[:3] - Tx
 
             Qe = self.robot_config.quaternion("EE", q=q)
             # Method 4

--- a/abr_control/controllers/path_planners/orientation.py
+++ b/abr_control/controllers/path_planners/orientation.py
@@ -2,7 +2,6 @@
 the timesteps (user defined profile) or n_timesteps (linear profile) passed in
 """
 import numpy as np
-import math
 
 import matplotlib.pyplot as plt
 
@@ -22,7 +21,7 @@ class Orientation(PathPlanner):
         1 (target orientation)
     """
 
-    def __init__(self, n_timesteps=None, timesteps=None, axes='rxyz'):
+    def __init__(self, n_timesteps=None, timesteps=None, axes="rxyz"):
         # assert n_timesteps is None or timesteps is None
         self.axes = axes
 
@@ -52,6 +51,10 @@ class Orientation(PathPlanner):
             the starting orientation as a quaternion
         target_orientation: list of 4 floats
             the target orientation as a quaternion
+        dr: float, Optional (Default: None)
+            if not None the path to target is broken up into n_timesteps segments.
+            Otherwise the number of timesteps are determined based on the set step
+            size in radians.
         """
         if len(orientation) == 3:
             raise ValueError(
@@ -70,24 +73,25 @@ class Orientation(PathPlanner):
 
         if dr is not None:
             # angle between two quaternions
-            # https://www.mathworks.com/matlabcentral/answers/476474-how-to-find-the-angle-between-two-quaternions
-            # q12 = transformations.quaternion_multiply(np.conj(orientation), target_orientation)
-            # q12 = transformations.quaternion_multiply(orientation, np.conj(target_orientation))
-            # angle_diff = 2 * math.atan2(np.linalg.norm(q12[1:]), q12[0])
-
-            # https://www.researchgate.net/post/How_do_I_calculate_the_smallest_angle_between_two_quaternions
+            # "https://www.researchgate.net/post"
+            # + "/How_do_I_calculate_the_smallest_angle_between_two_quaternions"
             # answer by luiz alberto radavelli
-            angle_diff = 2 * np.arccos(np.dot(target_orientation, orientation)
-                    /(np.linalg.norm(orientation)*np.linalg.norm(target_orientation)))
+            angle_diff = 2 * np.arccos(
+                np.dot(target_orientation, orientation)
+                / (np.linalg.norm(orientation) * np.linalg.norm(target_orientation))
+            )
 
             if angle_diff > np.pi:
-                min_angle_diff = 2*np.pi - angle_diff
+                min_angle_diff = 2 * np.pi - angle_diff
             else:
                 min_angle_diff = angle_diff
 
             self.n_timesteps = int(min_angle_diff / dr)
-            # self.n_timesteps = angle_diff/dr
-            print('%i steps to cover %f rad in %f sized steps' % (self.n_timesteps, angle_diff, dr))
+
+            print(
+                "%i steps to cover %f rad in %f sized steps"
+                % (self.n_timesteps, angle_diff, dr)
+            )
             self.timesteps = np.linspace(0, 1, self.n_timesteps)
 
         # stores the target Euler angles of the trajectory
@@ -101,9 +105,14 @@ class Orientation(PathPlanner):
                 quat, axes=self.axes
             )
         if self.n_timesteps == 0:
-            print('with the set step size, we reach the target in 1 step')
-            self.orientation_path = np.array([transformations.euler_from_quaternion(
-                    target_orientation, axes=self.axes)])
+            print("with the set step size, we reach the target in 1 step")
+            self.orientation_path = np.array(
+                [
+                    transformations.euler_from_quaternion(
+                        target_orientation, axes=self.axes
+                    )
+                ]
+            )
 
         self.n = 0
 
@@ -128,7 +137,6 @@ class Orientation(PathPlanner):
 
         self.n = min(self.n + 1, self.n_timesteps - 1)
         return orientation
-
 
     def _step(self, orientation, target_orientation):
         """ Calculates the next step along the planned trajectory
@@ -208,5 +216,3 @@ class Orientation(PathPlanner):
         plt.ylabel("Time step")
         plt.legend()
         plt.show()
-
-

--- a/abr_control/controllers/path_planners/orientation.py
+++ b/abr_control/controllers/path_planners/orientation.py
@@ -64,8 +64,6 @@ class Orientation(PathPlanner):
                 + "----------------------------------------------"
             )
 
-        print('or:', orientation)
-        print('tar:', target_orientation)
         self.target_angles = transformations.euler_from_quaternion(
             target_orientation, axes=self.axes
         )
@@ -87,11 +85,8 @@ class Orientation(PathPlanner):
             else:
                 min_angle_diff = angle_diff
 
-            print('angle_diff: ', angle_diff)
-            print('min angle diff: ', min_angle_diff)
             self.n_timesteps = int(min_angle_diff / dr)
             # self.n_timesteps = angle_diff/dr
-            print(self.n_timesteps)
             print('%i steps to cover %f rad in %f sized steps' % (self.n_timesteps, angle_diff, dr))
             self.timesteps = np.linspace(0, 1, self.n_timesteps)
 

--- a/abr_control/controllers/path_planners/orientation.py
+++ b/abr_control/controllers/path_planners/orientation.py
@@ -74,13 +74,22 @@ class Orientation(PathPlanner):
             # angle between two quaternions
             # https://www.mathworks.com/matlabcentral/answers/476474-how-to-find-the-angle-between-two-quaternions
             # q12 = transformations.quaternion_multiply(np.conj(orientation), target_orientation)
-            q12 = transformations.quaternion_multiply(orientation, np.conj(target_orientation))
-            angle_diff = 2 * math.atan2(np.linalg.norm(q12[1:]), q12[0])
+            # q12 = transformations.quaternion_multiply(orientation, np.conj(target_orientation))
+            # angle_diff = 2 * math.atan2(np.linalg.norm(q12[1:]), q12[0])
+
+            # https://www.researchgate.net/post/How_do_I_calculate_the_smallest_angle_between_two_quaternions
+            # answer by luiz alberto radavelli
+            angle_diff = 2 * np.arccos(np.dot(target_orientation, orientation)
+                    /(np.linalg.norm(orientation)*np.linalg.norm(target_orientation)))
+
             if angle_diff > np.pi:
-                angle_diff = 2*np.pi - angle_diff
+                min_angle_diff = 2*np.pi - angle_diff
+            else:
+                min_angle_diff = angle_diff
 
             print('angle_diff: ', angle_diff)
-            self.n_timesteps = int(angle_diff / dr)
+            print('min angle diff: ', min_angle_diff)
+            self.n_timesteps = int(min_angle_diff / dr)
             # self.n_timesteps = angle_diff/dr
             print(self.n_timesteps)
             print('%i steps to cover %f rad in %f sized steps' % (self.n_timesteps, angle_diff, dr))
@@ -97,8 +106,9 @@ class Orientation(PathPlanner):
                 quat, axes=self.axes
             )
         if self.n_timesteps == 0:
-            self.orientation_path = [transformations.euler_from_quaternion(
-                    target_orientation, axes=self.axes)]
+            print('with the set step size, we reach the target in 1 step')
+            self.orientation_path = np.array([transformations.euler_from_quaternion(
+                    target_orientation, axes=self.axes)])
 
         self.n = 0
 

--- a/abr_control/controllers/path_planners/path_planner.py
+++ b/abr_control/controllers/path_planners/path_planner.py
@@ -46,8 +46,9 @@ class PathPlanner:
         position = self.position_path[self.n]  # pylint: disable=E0203
         velocity = self.velocity_path[self.n]  # pylint: disable=E0203
         self.n = min(self.n + 1, self.n_timesteps - 1)
-        # some path planner may not end with zero target velocity depending on their parameters
-        # this will assure that you have zero target velocity when the filter is positionally at the final target
+        # some path planner may not end with zero target velocity depending on
+        # their parameters this will assure that you have zero target velocity
+        # when the filter is positionally at the final target
         if self.n == self.n_timesteps - 1:
             velocity = np.zeros(3)
 

--- a/abr_control/controllers/path_planners/path_planner.py
+++ b/abr_control/controllers/path_planners/path_planner.py
@@ -46,6 +46,10 @@ class PathPlanner:
         position = self.position_path[self.n]  # pylint: disable=E0203
         velocity = self.velocity_path[self.n]  # pylint: disable=E0203
         self.n = min(self.n + 1, self.n_timesteps - 1)
+        # some path planner may not end with zero target velocity depending on their parameters
+        # this will assure that you have zero target velocity when the filter is positionally at the final target
+        if self.n == self.n_timesteps - 1:
+            velocity = np.zeros(3)
 
         return position, velocity
 

--- a/abr_control/controllers/path_planners/second_order_dmp.py
+++ b/abr_control/controllers/path_planners/second_order_dmp.py
@@ -58,7 +58,7 @@ class SecondOrderDMP(PathPlanner):
 
         # we can control the DMP rollout speed with the time step size
         # the DMP will reach the target in 1s of sim time
-        dt = 1 / n_timesteps
+        dt = 1.2927 / n_timesteps
         self.dmps = pydmps.DMPs_discrete(n_dmps=3, n_bfs=50, dt=dt)
         self.dmps.imitate_path(y_des)
 
@@ -89,8 +89,12 @@ class SecondOrderDMP(PathPlanner):
         self.n = 0
 
         if plot:
+            plt.figure()
             plt.plot(self.position_path)
             plt.legend(["X", "Y", "Z"])
+            plt.figure()
+            plt.plot(self.velocity_path)
+            plt.legend(["DX", "DY", "DZ"])
             plt.show()
 
         return self.position_path, self.velocity_path

--- a/abr_control/controllers/path_planners/second_order_filter.py
+++ b/abr_control/controllers/path_planners/second_order_filter.py
@@ -89,7 +89,7 @@ class SecondOrderFilter(PathPlanner):
         self.n = 0
 
         if plot:
-            self.plot(target_position)
+            self._plot(target_position)
 
         self.position_path = np.array(self.position_path)
         self.velocity_path = np.array(self.velocity_path)

--- a/abr_control/controllers/sliding.py
+++ b/abr_control/controllers/sliding.py
@@ -4,8 +4,9 @@ from .controller import Controller
 
 
 class Sliding(Controller):
-    """ Implements sliding control based on the description
-    in (Slotine, 1987), default parameters from paper.
+    """ Implements sliding control based on the description in
+    [Slotine, Jean-Jacques E., and Weiping Li. "On the adaptive control of robot
+    manipulators." The international journal of robotics research 6.3 (1987): 49-59.]
 
     Parameters
     ----------

--- a/docs/examples/Mujoco/path_planning_inverse_kinematics.py
+++ b/docs/examples/Mujoco/path_planning_inverse_kinematics.py
@@ -1,0 +1,76 @@
+"""
+Running the joint controller with an inverse kinematics path planner
+for a Mujoco simulation. The path planning system will generate
+a trajectory in joint space that moves the end effector in a straight line
+to the target, which changes every n time steps.
+"""
+import numpy as np
+import sys
+
+from abr_control.interfaces.mujoco import Mujoco
+from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import path_planners
+from abr_control.utils import transformations
+
+# initialize our robot config for the jaco2
+robot_config = arm("ur5", use_sim_state=False)
+
+# create our path planner
+n_timesteps = 2000
+path_planner = path_planners.InverseKinematics(robot_config)
+
+# create our interface
+dt = 0.001
+interface = Mujoco(robot_config, dt=dt)
+interface.connect()
+interface.send_target_angles(robot_config.START_ANGLES)
+feedback = interface.get_feedback()
+
+try:
+    print("\nSimulation starting...")
+    print("Click to move the target.\n")
+
+    count = 0
+    while 1:
+        if interface.viewer.exit:
+            glfw.destroy_window(interface.viewer.window)
+            break
+
+        if count % n_timesteps == 0:
+            feedback = interface.get_feedback()
+            target_xyz = np.array([
+                np.random.random() * .5 - .25,
+                np.random.random() * .5 - .25,
+                np.random.random() * .5 + .5,
+            ])
+            R = robot_config.R("EE", q=feedback["q"])
+            target_orientation = transformations.euler_from_matrix(R, "sxyz")
+            # update the position of the target
+            interface.set_mocap_xyz("target", target_xyz)
+
+            # can use 3 different methods to calculate inverse kinematics
+            # see inverse_kinematics.py file for details
+            path_planner.generate_path(
+                position=feedback["q"],
+                target_position=np.hstack([target_xyz, target_orientation]),
+                method=3,
+                dt=0.005,
+                n_timesteps=n_timesteps,
+                plot=False,
+            )
+
+        # returns desired [position, velocity]
+        target = path_planner.next()[0]
+
+        # use position control
+        print('target angles: ', target[:robot_config.N_JOINTS])
+        interface.send_target_angles(target[: robot_config.N_JOINTS])
+        interface.viewer.render()
+
+        count += 1
+
+finally:
+    # stop and reset the simulation
+    interface.disconnect()
+
+    print("Simulation terminated...")

--- a/docs/examples/Mujoco/path_planning_inverse_kinematics.py
+++ b/docs/examples/Mujoco/path_planning_inverse_kinematics.py
@@ -5,7 +5,7 @@ a trajectory in joint space that moves the end effector in a straight line
 to the target, which changes every n time steps.
 """
 import numpy as np
-import sys
+import glfw
 
 from abr_control.interfaces.mujoco import Mujoco
 from abr_control.arms.mujoco_config import MujocoConfig as arm

--- a/docs/examples/PyGame/path_planning_inverse_kinematics.py
+++ b/docs/examples/PyGame/path_planning_inverse_kinematics.py
@@ -25,7 +25,7 @@ arm_sim = arm.ArmSim(robot_config)
 
 if use_force_control:
     # create an operational space controller
-    ctrlr = Joint(robot_config, kp=100, kv=30)
+    ctrlr = Joint(robot_config, kp=300, kv=20)
 
 # create our path planner
 n_timesteps = 2000
@@ -61,22 +61,21 @@ try:
             path_planner.generate_path(
                 position=feedback["q"],
                 target_position=np.hstack([target_xyz, target_orientation]),
-                method=1,
+                method=3,
                 dt=0.005,
                 n_timesteps=n_timesteps,
                 plot=False,
             )
 
         # returns desired [position, velocity]
-        target = path_planner.next()
+        target, _ = path_planner.next()
 
         if use_force_control:
             # generate an operational space control signal
             u = ctrlr.generate(
                 q=feedback["q"],
                 dq=feedback["dq"],
-                target=target[0],
-                target_velocity=target[1],
+                target=target,
             )
 
             # apply the control signal, step the sim forward


### PR DESCRIPTION
Changing the inverse kinematics path planner to run with `Tx` instead of `T`, because only the position of the EE is needed and the Mujoco robot config doesn't have `T` implemented. Now it runs with Mujoco.
Added an example of that running in Mujoco and cleaned up the PyGame inverse kinematics example as well to run smoother. 

Also updates to the orientation planner to allow for a constant rotation speed.