### PR TITLE
Adding in support for spherical joint control in Mujoco

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -43,6 +43,13 @@ setup_py:
     - "Topic :: Scientific/Engineering :: Artificial Intelligence"
 
 setup_cfg:
+  codespell:
+    ignore_words:
+      - DOF
+      - dof
+      - hist
+      - nd
+      - compiletime
   coverage:
     omit_files:
       - "abr_control/_vendor/*"
@@ -94,13 +101,6 @@ travis_yml:
       - bdist_wheel
 
 ci_scripts:
-  - template: static
-    codespell_ignore_words:
-        - DOF
-        - dof
-        - hist
-        - nd
-        - compiletime
   - template: test
     output_name: test-coverage
     coverage: true
@@ -108,5 +108,4 @@ ci_scripts:
 codecov_yml: {}
 
 pre_commit_config_yaml: {}
-
 pyproject_toml: {}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,5 +9,5 @@ repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.6.4
     hooks:
-      - id: isort
-        files: \.py$
+    - id: isort
+      files: \.py$

--- a/abr_control/arms/mujoco_config.py
+++ b/abr_control/arms/mujoco_config.py
@@ -120,10 +120,10 @@ class MujocoConfig:
         self.joint_vel_addrs = np.copy(joint_vel_addrs)
         self.joint_dyn_addrs = np.copy(joint_dyn_addrs)
 
-        # number of joints in the robot arm
-        self.N_JOINTS = len(self.joint_pos_addrs)
+        # number of controllable joints in the robot arm
+        self.N_JOINTS = len(self.joint_dyn_addrs)
         # number of joints in the Mujoco simulation
-        N_ALL_JOINTS = int(len(self.sim.data.get_body_jacp("EE")) / 3)
+        N_ALL_JOINTS = self.sim.model.nv
 
         # need to calculate the joint_dyn_addrs indices in flat vectors returned
         # for the Jacobian

--- a/abr_control/arms/onejoint/balljoint.xml
+++ b/abr_control/arms/onejoint/balljoint.xml
@@ -1,0 +1,60 @@
+<mujoco model="onelink">
+
+    <custom>
+        <numeric name="START_ANGLES" data="0.0"/>
+    </custom>
+
+    <contact>
+        <exclude body1="hand" body2="EE"/>
+        <exclude body1="hand" body2="base_link"/>
+        <exclude body1="hand" body2="link1"/>
+
+        <exclude body1="target" body2="EE"/>
+        <exclude body1="target" body2="base_link"/>
+        <exclude body1="target" body2="link1"/>
+    </contact>
+
+    <worldbody>
+        <body name="hand" pos="0 0 0" mocap="true">
+            <geom type="box" size=".02 .04 .06" rgba="0 .9 0 .5" contype="2"/>
+            <inertial pos="0 0 0" mass="0" diaginertia="0 0 0" />
+        </body>
+        <body name="target" pos="0 0 0" mocap="true">
+            <geom type="sphere" size="0.05" rgba=".9 0 0 .5"/>
+            <inertial pos="0 0 0" mass="0" diaginertia="0 0 0" />
+        </body>
+
+        <body name="floor" pos="0 0 0" mocap="true">
+            <geom type="box" size="1 1 0.001" rgba="0.99 0.99 0.99 1" contype="2"/>
+            <inertial pos="0 0 0" mass="0" diaginertia="0 0 0" />
+        </body>
+
+        <light pos="0 1 1" dir="0 -1 -1" diffuse="1 1 1"/>
+
+        <body name="base_link" pos="0 0 0.05">
+            <geom name="link0" type="cylinder" pos="0 0 0" size="0.025 0.025" rgba="0 0 1 0.9"/>
+            <inertial pos="0 0 0" mass="0" diaginertia="0 0 0" />
+
+            <body name="link1" pos="0 0 0.05">
+                <joint name='joint0' type="ball" pos="0 0 0"/>
+                <inertial pos="0 0 0.1" mass="2" diaginertia="0.226891 0.226891 0.0151074" />
+                <geom name="link1" type="cylinder" pos="0 0 0.1" size="0.025 0.1" rgba="0 1 0 0.9"/>
+
+                <body name="EE" pos="0 0 .4">
+                    <inertial pos="0 0 0" mass="0" diaginertia="0 0 0" />
+                </body>
+
+            </body>
+
+        </body>
+
+    </worldbody>
+
+    <actuator>
+        <!-- the order for actuators of the ball joint is important -->
+        <motor name="joint0_motor0" joint="joint0" gear="1 0 0 0 0 0"/>
+        <motor name="joint0_motor1" joint="joint0" gear="0 1 0 0 0 0"/>
+        <motor name="joint0_motor2" joint="joint0" gear="0 0 1 0 0 0"/>
+    </actuator>
+
+</mujoco>

--- a/abr_control/controllers/resting_config.py
+++ b/abr_control/controllers/resting_config.py
@@ -1,4 +1,4 @@
-# TODO: set up to work with ball joints / quaternion postions
+# TODO: set up to work with ball joints / quaternion positions
 
 import numpy as np
 

--- a/abr_control/controllers/resting_config.py
+++ b/abr_control/controllers/resting_config.py
@@ -1,3 +1,5 @@
+# TODO: set up to work with ball joints / quaternion postions
+
 import numpy as np
 
 from .controller import Controller
@@ -33,7 +35,7 @@ class RestingConfig(Controller):
         # account for going across 2*pi line when calculating
         # distance / direction
         q_des = np.zeros(len(q))
-        dq_des = np.zeros(len(q))
+        dq_des = np.zeros(len(dq))
         q_des[self.rest_indices] = (
             self.rest_angles[self.rest_indices] - q[self.rest_indices] + np.pi
         ) % (np.pi * 2) - np.pi

--- a/abr_control/controllers/signals/dynamics_adaptation.py
+++ b/abr_control/controllers/signals/dynamics_adaptation.py
@@ -66,7 +66,7 @@ class DynamicsAdaptation:
         tau_input=0.012,
         tau_training=0.012,
         tau_output=0.2,
-        **kwargs,
+        **kwargs
     ):
 
         self.n_neurons = n_neurons

--- a/abr_control/controllers/signals/dynamics_adaptation.py
+++ b/abr_control/controllers/signals/dynamics_adaptation.py
@@ -66,7 +66,7 @@ class DynamicsAdaptation:
         tau_input=0.012,
         tau_training=0.012,
         tau_output=0.2,
-        **kwargs
+        **kwargs,
     ):
 
         self.n_neurons = n_neurons

--- a/abr_control/interfaces/mujoco.py
+++ b/abr_control/interfaces/mujoco.py
@@ -96,10 +96,10 @@ class Mujoco(Interface):
             if ii in joint_ids:
                 self.joint_dyn_addrs.append(index)
             if joint_type == 0:  # free joint
-                self.joint_dyn_addrs += [jj+index for jj in range(1, 6)]
+                self.joint_dyn_addrs += [jj + index for jj in range(1, 6)]
                 index += 6  # derivative has 6 dimensions
             elif joint_type == 1:  # ball joint
-                self.joint_dyn_addrs += [jj+index for jj in range(1, 3)]
+                self.joint_dyn_addrs += [jj + index for jj in range(1, 3)]
                 index += 3  # derivative has 3 dimension
             else:  # slide or hinge joint
                 index += 1  # derivative has 1 dimensions

--- a/abr_control/interfaces/mujoco.py
+++ b/abr_control/interfaces/mujoco.py
@@ -67,6 +67,22 @@ class Mujoco(Interface):
         self.joint_pos_addrs = [model.get_joint_qpos_addr(name) for name in joint_names]
         self.joint_vel_addrs = [model.get_joint_qvel_addr(name) for name in joint_names]
 
+        joint_pos_addrs = []
+        for elem in self.joint_pos_addrs:
+            if isinstance(elem, tuple):
+                joint_pos_addrs += [ii for ii in range(elem[0], elem[1])]
+            else:
+                joint_pos_addrs.append(elem)
+        self.joint_pos_addrs = joint_pos_addrs
+
+        joint_vel_addrs = []
+        for elem in self.joint_vel_addrs:
+            if isinstance(elem, tuple):
+                joint_vel_addrs += [ii for ii in range(elem[0], elem[1])]
+            else:
+                joint_vel_addrs.append(elem)
+        self.joint_vel_addrs = joint_vel_addrs
+
         # Need to also get the joint rows of the Jacobian, inertia matrix, and
         # gravity vector. This is trickier because if there's a quaternion in
         # the joint (e.g. a free joint or a ball joint) then the joint position
@@ -80,9 +96,11 @@ class Mujoco(Interface):
             if ii in joint_ids:
                 self.joint_dyn_addrs.append(index)
             if joint_type == 0:  # free joint
+                self.joint_dyn_addrs += [jj+index for jj in range(1, 6)]
                 index += 6  # derivative has 6 dimensions
             elif joint_type == 1:  # ball joint
-                index += 3  # derivative has 3 dimensions
+                self.joint_dyn_addrs += [jj+index for jj in range(1, 3)]
+                index += 3  # derivative has 3 dimension
             else:  # slide or hinge joint
                 index += 1  # derivative has 1 dimensions
 

--- a/abr_control/interfaces/mujoco.py
+++ b/abr_control/interfaces/mujoco.py
@@ -70,7 +70,7 @@ class Mujoco(Interface):
         joint_pos_addrs = []
         for elem in self.joint_pos_addrs:
             if isinstance(elem, tuple):
-                joint_pos_addrs += [ii for ii in range(elem[0], elem[1])]
+                joint_pos_addrs += list(range(elem[0], elem[1]))
             else:
                 joint_pos_addrs.append(elem)
         self.joint_pos_addrs = joint_pos_addrs
@@ -78,7 +78,7 @@ class Mujoco(Interface):
         joint_vel_addrs = []
         for elem in self.joint_vel_addrs:
             if isinstance(elem, tuple):
-                joint_vel_addrs += [ii for ii in range(elem[0], elem[1])]
+                joint_vel_addrs += list(range(elem[0], elem[1]))
             else:
                 joint_vel_addrs.append(elem)
         self.joint_vel_addrs = joint_vel_addrs

--- a/docs/examples/Mujoco/mujoco_balljoint.xml
+++ b/docs/examples/Mujoco/mujoco_balljoint.xml
@@ -1,0 +1,35 @@
+<mujoco model="balljoint">
+    <compiler angle="radian"/>
+    <contact>
+        <exclude body1="base_link" body2="link0"/>
+    </contact>
+
+    <worldbody>
+        <body name="hand" pos="0 0 0" mocap="true">
+            <geom name="hand" type="box" size=".02 .04 .06" rgba="0 .9 0 .5" contype="2" conaffinity="2"/>
+        </body>
+
+        <body name="target" pos="0 0 0" mocap="true">
+            <geom name="target" type="sphere" size=".1 .2" rgba=".9 0 0 .5" contype="4" conaffinity="4"/>
+        </body>
+
+        <body name="base_link" pos="0 0 0">
+            <geom name="base_link0" type="capsule" size=".1 .3" pos="0 0 0" rgba=".7 .7 .7 1" euler="1.57 0 0"/>
+            <geom name="base_link1" type="capsule" size=".1 .3" pos="0 0 0" rgba=".7 .7 .7 1" euler="0 1.57 0"/>
+
+            <body name="link0" pos="0 0 0">
+                <joint name='joint0' type="ball" pos="0 0 0" axis="1 0 0"/>
+                <geom type="capsule" pos="0 0 .5" size=".1 .5" euler="0 0 0" rgba=".7 .7 .7 .5"/>
+
+                <body name="EE" pos="0 0 1"/>
+            </body>
+        </body>
+    </worldbody>
+
+    <actuator>
+        <motor name="joint0_motor0" joint="joint0" gear="1 0 0 0 0 0"/>
+        <motor name="joint0_motor1" joint="joint0" gear="0 1 0 0 0 0"/>
+        <motor name="joint0_motor2" joint="joint0" gear="0 0 1 0 0 0"/>
+    </actuator>
+</mujoco>
+

--- a/docs/examples/Mujoco/position_control_osc_balljoint.py
+++ b/docs/examples/Mujoco/position_control_osc_balljoint.py
@@ -3,7 +3,6 @@ Move the jao2 Mujoco arm to a target position.
 The simulation ends after 1500 time steps, and the
 trajectory of the end-effector is plotted in 3D.
 """
-import sys
 import traceback
 import numpy as np
 import glfw

--- a/docs/examples/Mujoco/position_control_osc_balljoint.py
+++ b/docs/examples/Mujoco/position_control_osc_balljoint.py
@@ -1,0 +1,141 @@
+"""
+Move the jao2 Mujoco arm to a target position.
+The simulation ends after 1500 time steps, and the
+trajectory of the end-effector is plotted in 3D.
+"""
+import sys
+import traceback
+import numpy as np
+import glfw
+
+from abr_control.controllers import OSC
+from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.interfaces.mujoco import Mujoco
+from abr_control.utils import transformations
+
+
+# initialize our robot config for the jaco2
+robot_config = arm("mujoco_balljoint.xml", folder=".")
+
+# create our Mujoco interface
+interface = Mujoco(robot_config, dt=0.001)
+interface.connect()
+
+# instantiate controller
+ctrlr = OSC(
+    robot_config,
+    kp=200,
+    # control (x, y, z) out of [x, y, z, alpha, beta, gamma]
+    ctrlr_dof=[True, True, True, False, False, False],
+)
+
+# set up lists for tracking data
+ee_track = []
+target_track = []
+
+target_geom_id = interface.sim.model.geom_name2id("target")
+green = [0, 0.9, 0, 0.5]
+red = [0.9, 0, 0, 0.5]
+
+# get the end-effector's initial position
+targets = [
+    np.array([-0.3, -0.3, 0.9]),
+    np.array([0.3, -0.3, 0.9]),
+    np.array([0.3, 0.3, 0.9]),
+    np.array([-0.3, 0.3, 0.9]),
+]
+target_index = 0
+interface.set_mocap_xyz(name="target", xyz=targets[0])
+
+try:
+    # get the end-effector's initial position
+    feedback = interface.get_feedback()
+    start = robot_config.Tx("EE", feedback["q"])
+
+    count = 0.0
+    print("\nSimulation starting...\n")
+    while 1:
+        if interface.viewer.exit:
+            glfw.destroy_window(interface.viewer.window)
+            break
+        # get joint angle and velocity feedback
+        feedback = interface.get_feedback()
+
+        target = np.hstack(
+            [
+                interface.get_xyz("target"),
+                transformations.euler_from_quaternion(
+                    interface.get_orientation("target"), "rxyz"
+                ),
+            ]
+        )
+
+        # calculate the control signal
+        u = ctrlr.generate(
+            q=feedback["q"],
+            dq=feedback["dq"],
+            target=target,
+        )
+
+        # send forces into Mujoco, step the sim forward
+        interface.send_forces(u)
+
+        # calculate end-effector position
+        ee_xyz = robot_config.Tx("EE", q=feedback["q"])
+        # track data
+        ee_track.append(np.copy(ee_xyz))
+        target_track.append(np.copy(target[:3]))
+
+        error = np.linalg.norm(ee_xyz - target[:3])
+        if error < 0.02:
+            interface.sim.model.geom_rgba[target_geom_id] = green
+            count += 1
+        else:
+            count = 0
+            interface.sim.model.geom_rgba[target_geom_id] = red
+
+        if count >= 50:
+            target_index += 1
+            interface.set_mocap_xyz(
+                name="target", xyz=targets[target_index % len(targets)]
+            )
+            count = 0
+
+except:
+    print(traceback.format_exc())
+
+finally:
+    # stop and reset the Mujoco simulation
+    interface.disconnect()
+
+    print("Simulation terminated...")
+
+    ee_track = np.array(ee_track)
+    target_track = np.array(target_track)
+
+    if ee_track.shape[0] > 0:
+        # plot distance from target and 3D trajectory
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d import axes3d  # pylint: disable=W0611
+
+        fig = plt.figure(figsize=(8, 12))
+        ax1 = fig.add_subplot(211)
+        ax1.set_ylabel("Distance (m)")
+        ax1.set_xlabel("Time (ms)")
+        ax1.set_title("Distance to target")
+        ax1.plot(
+            np.sqrt(np.sum((np.array(target_track) - np.array(ee_track)) ** 2, axis=1))
+        )
+
+        ax2 = fig.add_subplot(212, projection="3d")
+        ax2.set_title("End-Effector Trajectory")
+        ax2.plot(ee_track[:, 0], ee_track[:, 1], ee_track[:, 2], label="ee_xyz")
+        ax2.scatter(
+            target_track[0, 0],
+            target_track[0, 1],
+            target_track[0, 2],
+            label="target",
+            c="r",
+        )
+        ax2.legend()
+        plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 requires = ["setuptools", "wheel"]
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36']
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,3 +138,6 @@ valid-metaclass-classmethod-first-arg = metacls
 [pylint.reports]
 reports = no
 score = no
+
+[codespell]
+skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./.git,*/_vendor,

--- a/setup.cfg
+++ b/setup.cfg
@@ -141,3 +141,4 @@ score = no
 
 [codespell]
 skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./.git,*/_vendor,
+ignore-words-list = DOF,dof,hist,nd,compiletime


### PR DESCRIPTION
Had to update the indexing in several places to allow for ball joints to be used, because ball joint positions are defined by quaternions (4d) but their velocity is 3d. Surprisingly didn't have to add much to address this case, though.