### PR TITLE
Jaco2

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -1,6 +1,7 @@
 project_name: ABR Control
 pkg_name: abr_control
 repo_name: abr/abr_control
+min_python: 3.5
 author_email: travis.dewolf@appliedbrainresearch.com
 description: Robotic arm control in Python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - SCRIPT="test"
     - TEST_ARGS=""
     - BRANCH_NAME="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
-    - PIP_USE_FEATURE="2020-resolver"
 
 jobs:
   include:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,10 +26,6 @@ If you want to fix a bug or add a feature to ABR Control,
 we welcome pull requests.
 Ensure that you fill out all sections of the pull request template,
 deleting the comments as you go.
-We check most aspects of code style automatically.
-Please refer to our
-`code style guide <https://www.nengo.ai/nengo-bones/style.html>`_
-for things that we check manually.
 
 Contributor agreement
 =====================

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,7 @@ To install ABR Control, clone this repository and run::
     sudo apt-get install python-dev
     sudo apt-get install libfreetype6-dev
     conda activate your_environment
-    python setup.py install
-    python setup.py develop
+    pip install -e .
 
 ABR Control is tested to work on Python 3.6+, Python 2 is not supported.
 

--- a/abr_control/controllers/signals/dynamics_adaptation.py
+++ b/abr_control/controllers/signals/dynamics_adaptation.py
@@ -66,7 +66,7 @@ class DynamicsAdaptation:
         tau_input=0.012,
         tau_training=0.012,
         tau_output=0.2,
-        **kwargs,
+        **kwargs
     ):
 
         self.n_neurons = n_neurons

--- a/abr_control/utils/download_meshes.py
+++ b/abr_control/utils/download_meshes.py
@@ -1,7 +1,10 @@
 import os
 import zipfile
 
-import requests
+try:
+    import requests
+except:
+    print('To download mujoco stl files, you need to "pip install requests"')
 
 
 def check_and_download(name, google_id, files=None, force_download=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 requires = ["setuptools", "wheel"]
 
 [tool.black]
-target-version = ['py36']
+target-version = ['py35']
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -140,5 +140,5 @@ reports = no
 score = no
 
 [codespell]
-skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./.git,*/_vendor,
+skip = ./build,*/_build,*-checkpoint.ipynb,./.eggs,./*.egg-info,./.git,*/_vendor,./.mypy_cache,
 ignore-words-list = DOF,dof,hist,nd,compiletime

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "optional": optional_req,
         "tests": tests_req,
     },
-    python_requires=">=3.6",
+    python_requires=">=3.5",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: ABR Control",


### PR DESCRIPTION
- Updated nengobones.
- Added try except around utils/download_meshes.py with a printout to tell the user to `pip install requests` to use the mujoco interface. Without this there is always an error thrown trying to use abr_control, even without mujoco.
- Changed min python version to 3.5 for compatibility with abr_jaco2. This limit is required to compile the jaco2 interface.
- Ran nengobones, isort, and black.
- Travis-ci tests all passing.