### PR TITLE
Ball joint controller

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,16 @@ in your anaconda environment and run::
     pip install glfw>=1.8.3
     pip install requests
 
+Additionally, in Ubuntu 20.04 you will need::
+
+    sudo apt install libomesa6-dev
+    sudo apt install libglew-dev
+    sudo apt install patchelf
+
+and add the following line to your `~/.bashrc` file::
+
+    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libGLEW.so
+
 Pygame
 ------
 If you would like to use the Pygame API, from your anaconda environment run::

--- a/abr_control/arms/mujoco_config.py
+++ b/abr_control/arms/mujoco_config.py
@@ -32,10 +32,14 @@ class MujocoConfig:
             specifies what folder to find the xml_file, if None specified will
             checking in abr_control/arms/xml_file (see above for xml_file)
         use_sim_state: Boolean, optional (Default: True)
-            If set true, the q and dq values passed in to the functions are
+            If set False, the state information is provided by the user, which
+            is then used to calculate the corresponding dynamics values.
+            The state is then set back to the sim state prior to the user
+            provided state.
+            If set true, any q and dq values passed in to the functions are
             ignored, and the current state of the simulator is used to
-            calculate all functions. Can speed up simulation by not resetting
-            the state on every call.
+            calculate all functions. This can speed up the simulation, because
+            the step of resetting the state on every call is omitted.
         force_download: boolean, Optional (Default: False)
             True to force downloading the mesh and texture files, useful when new files
             are added that may be missing.
@@ -175,7 +179,7 @@ class MujocoConfig:
         if u is not None:
             self.sim.data.ctrl[:] = np.copy(u)
 
-        # move simulation forward to calculate new kinamtic information
+        # move simulation forward to calculate new kinematic information
         self.sim.forward()
 
         return old_q, old_dq, old_u

--- a/abr_control/controllers/joint.py
+++ b/abr_control/controllers/joint.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from .controller import Controller
+from abr_control.utils import transformations
+from abr_control.utils.transformations import quaternion_multiply, quaternion_conjugate
 
 
 class Joint(Controller):
@@ -17,15 +19,86 @@ class Joint(Controller):
         proportional gain term
     kv : float, optional (Default: None)
         derivative gain term, a good starting point is sqrt(kp)
+    quaternions : list, optional (Default: None)
+        a boolean list of which joints are quaternions
     """
 
-    def __init__(self, robot_config, kp=1, kv=None):
+    def __init__(self, robot_config, kp=1, kv=None, quaternions=None,
+                 account_for_gravity=True):
         super().__init__(robot_config)
 
         self.kp = kp
         self.kv = np.sqrt(self.kp) if kv is None else kv
+        self.account_for_gravity = account_for_gravity
         self.ZEROS_N_JOINTS = np.zeros(robot_config.N_JOINTS)
-        self.q_tilde = np.copy(self.ZEROS_N_JOINTS)
+
+        if quaternions is not None:
+            self.quaternions = quaternions
+            self.q_tilde = self.q_tilde_quat
+        else:
+            self.q_tilde = self.q_tilde_angle
+
+    def q_tilde_angle(self, q, target):
+        # calculate the direction for each joint to move, wrapping
+        # around the -pi to pi limits to find the shortest distance
+        q_tilde = ((target - q + np.pi) % (np.pi * 2)) - np.pi
+        return q_tilde
+
+    def q_tilde_quat(self, q, target):
+        """Compute the error signal when there are quaternions in the state
+        space and target signals. If there are quaternions in the state space,
+        calculate the error and then transform them to 3D space for the control
+        signal.
+
+        NOTE: Assumes that for every quaternion there are 3 motors, that effect
+        movement along the x, y, and z axes, applied in that order.
+
+        Parameters
+        ----------
+        q : float numpy.array
+            mix of joint angles and quaternions [quaternions & radians]
+        target : float numpy.array
+            mix of target joint angles and quaternions [quaternions & radians]
+        """
+        # for each quaternion in the list, the output size is reduced by 1
+        q_tilde = np.zeros(len(q) - np.sum(self.quaternions))
+
+        q_index = 0
+        q_tilde_index = 0
+
+        for quat_bool in self.quaternions:
+            if quat_bool:
+                # if the joint position is a quaternion, calculate error
+                joint_q = q[q_index:q_index+4]
+                error = quaternion_multiply(
+                    target[q_index:q_index+4],
+                    quaternion_conjugate(joint_q),
+                )
+
+                # NOTE: we need to rotate this back to undo the current angle
+                # because the actuators don't rotate with the ball joint
+                u = quaternion_multiply(
+                    quaternion_conjugate(joint_q),
+                    quaternion_multiply(
+                        error,
+                        joint_q,
+                    )
+                )
+
+                # convert from quaternion to 3D angular forces to apply
+                # https://studywolf.wordpress.com/2018/12/03/force-control-of-task-space-orientation/
+                q_tilde[q_tilde_index:q_tilde_index+3] = u[1:] * np.sign(u[0])
+
+                q_index += 4
+                q_tilde_index += 3
+            else:
+                q_tilde[q_tilde_index] = self.q_tilde_angle(
+                    q[q_index], target[q_index])
+
+                q_index += 1
+                q_tilde_index += 1
+
+        return q_tilde
 
     def generate(self, q, dq, target, target_velocity=None):
         """Generate a joint space control signal
@@ -45,14 +118,13 @@ class Joint(Controller):
         if target_velocity is None:
             target_velocity = self.ZEROS_N_JOINTS
 
-        # calculate the direction for each joint to move, wrapping
-        # around the -pi to pi limits to find the shortest distance
-        self.q_tilde = ((target - q + np.pi) % (np.pi * 2)) - np.pi
+        q_tilde = self.q_tilde(q, target)
 
         # get the joint space inertia matrix
         M = self.robot_config.M(q)
-        u = np.dot(M, (self.kp * self.q_tilde + self.kv * (target_velocity - dq)))
+        u = np.dot(M, (self.kp * q_tilde + self.kv * (target_velocity - dq)))
         # account for gravity
-        u -= self.robot_config.g(q)
+        if self.account_for_gravity:
+            u -= self.robot_config.g(q)
 
         return u

--- a/abr_control/controllers/joint.py
+++ b/abr_control/controllers/joint.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from .controller import Controller
-from abr_control.utils import transformations
 from abr_control.utils.transformations import quaternion_multiply, quaternion_conjugate
 
 
@@ -68,6 +67,7 @@ class Joint(Controller):
 
         for quat_bool in self.quaternions:
             if quat_bool:
+
                 # if the joint position is a quaternion, calculate error
                 joint_q = q[q_index:q_index+4]
                 error = quaternion_multiply(

--- a/abr_control/controllers/joint.py
+++ b/abr_control/controllers/joint.py
@@ -1,7 +1,8 @@
 import numpy as np
 
+from abr_control.utils.transformations import quaternion_conjugate, quaternion_multiply
+
 from .controller import Controller
-from abr_control.utils.transformations import quaternion_multiply, quaternion_conjugate
 
 
 class Joint(Controller):
@@ -22,8 +23,9 @@ class Joint(Controller):
         a boolean list of which joints are quaternions
     """
 
-    def __init__(self, robot_config, kp=1, kv=None, quaternions=None,
-                 account_for_gravity=True):
+    def __init__(
+        self, robot_config, kp=1, kv=None, quaternions=None, account_for_gravity=True
+    ):
         super().__init__(robot_config)
 
         self.kp = kp
@@ -69,9 +71,9 @@ class Joint(Controller):
             if quat_bool:
 
                 # if the joint position is a quaternion, calculate error
-                joint_q = q[q_index:q_index+4]
+                joint_q = q[q_index : q_index + 4]
                 error = quaternion_multiply(
-                    target[q_index:q_index+4],
+                    target[q_index : q_index + 4],
                     quaternion_conjugate(joint_q),
                 )
 
@@ -82,18 +84,17 @@ class Joint(Controller):
                     quaternion_multiply(
                         error,
                         joint_q,
-                    )
+                    ),
                 )
 
                 # convert from quaternion to 3D angular forces to apply
                 # https://studywolf.wordpress.com/2018/12/03/force-control-of-task-space-orientation/
-                q_tilde[q_tilde_index:q_tilde_index+3] = u[1:] * np.sign(u[0])
+                q_tilde[q_tilde_index : q_tilde_index + 3] = u[1:] * np.sign(u[0])
 
                 q_index += 4
                 q_tilde_index += 3
             else:
-                q_tilde[q_tilde_index] = self.q_tilde_angle(
-                    q[q_index], target[q_index])
+                q_tilde[q_tilde_index] = self.q_tilde_angle(q[q_index], target[q_index])
 
                 q_index += 1
                 q_tilde_index += 1

--- a/abr_control/controllers/osc.py
+++ b/abr_control/controllers/osc.py
@@ -31,7 +31,7 @@ class OSC(Controller):
         [x, y, z, alpha, beta, gamma]
         NOTE: if more ctrlr_dof are specified than degrees of freedom in the
         robotic system, the controller will perform poorly
-    null_controler: Controller, optional (Default: None)
+    null_controller: Controller, optional (Default: None)
         A controller to generate a secondary control signal to be
         applied in the null space of the OSC signal (i.e. applied as much
         as possible without affecting the movement of the end-effector)

--- a/abr_control/controllers/path_planners/orientation.py
+++ b/abr_control/controllers/path_planners/orientation.py
@@ -21,7 +21,9 @@ class Orientation(PathPlanner):
         1 (target orientation)
     """
 
-    def __init__(self, n_timesteps=None, timesteps=None, axes="rxyz", output_format="euler"):
+    def __init__(
+        self, n_timesteps=None, timesteps=None, axes="rxyz", output_format="euler"
+    ):
         # assert n_timesteps is None or timesteps is None
         self.axes = axes
         self.output_format = output_format
@@ -97,7 +99,7 @@ class Orientation(PathPlanner):
 
         # stores the target Euler angles of the trajectory
         self.orientation_path = []
-        for ii in range(self.n_timesteps):
+        for _ in range(self.n_timesteps):
             quat = self._step(
                 orientation=orientation, target_orientation=target_orientation
             )

--- a/abr_control/controllers/resting_config.py
+++ b/abr_control/controllers/resting_config.py
@@ -2,10 +2,10 @@
 
 import numpy as np
 
-from .controller import Controller
+from .joint import Joint
 
 
-class RestingConfig(Controller):
+class RestingConfig(Joint):
     """Move the arm towards a set of 'resting state' joint angles
 
     Parameters
@@ -15,13 +15,11 @@ class RestingConfig(Controller):
         such as number of joints, number of links, mass information etc.
     """
 
-    def __init__(self, robot_config, rest_angles, kp, kv=None):
-        super().__init__(robot_config)
+    def __init__(self, robot_config, rest_angles, **kwargs):
+        super().__init__(robot_config, account_for_gravity=False, **kwargs)
 
         self.rest_angles = np.asarray(rest_angles)
         self.rest_indices = [val is not None for val in rest_angles]
-        self.kp = kp
-        self.kv = np.sqrt(kp) if kv is None else kv
 
     def generate(self, q, dq):
         """Generates the control signal
@@ -32,16 +30,4 @@ class RestingConfig(Controller):
           the current joint angle velocity [radians/second]
         """
 
-        # account for going across 2*pi line when calculating
-        # distance / direction
-        q_des = np.zeros(len(q))
-        dq_des = np.zeros(len(dq))
-        q_des[self.rest_indices] = (
-            self.rest_angles[self.rest_indices] - q[self.rest_indices] + np.pi
-        ) % (np.pi * 2) - np.pi
-        dq_des[self.rest_indices] = dq[self.rest_indices]
-
-        # calculate joint space inertia matrix
-        M = self.robot_config.M(q=q)
-
-        return np.dot(M, (self.kp * q_des - self.kv * dq_des))
+        return super().generate(q, dq, target=self.rest_angles)

--- a/abr_control/controllers/signals/dynamics_adaptation.py
+++ b/abr_control/controllers/signals/dynamics_adaptation.py
@@ -69,7 +69,9 @@ class DynamicsAdaptation:
         **kwargs
     ):
         # set up means and variances to be same dimensionality as original input signal
-        self.variances = np.ones(n_input) if variances is None else np.asarray(variances)
+        self.variances = (
+            np.ones(n_input) if variances is None else np.asarray(variances)
+        )
         self.means = np.zeros(n_input) if means is None else np.asarray(means)
 
         self.n_neurons = n_neurons

--- a/abr_control/controllers/signals/dynamics_adaptation.py
+++ b/abr_control/controllers/signals/dynamics_adaptation.py
@@ -68,6 +68,9 @@ class DynamicsAdaptation:
         tau_output=0.2,
         **kwargs
     ):
+        # set up means and variances to be same dimensionality as original input signal
+        self.variances = np.ones(n_input) if variances is None else np.asarray(variances)
+        self.means = np.zeros(n_input) if means is None else np.asarray(means)
 
         self.n_neurons = n_neurons
         self.n_ensembles = n_ensembles
@@ -201,7 +204,6 @@ class DynamicsAdaptation:
         training_signal : numpy.array
             the learning signal to drive adaptation
         """
-
         # if means or variances was defined, self.means is not None
         if self.means is not None or self.variances is not None:
             input_signal = self.scale_inputs(input_signal)

--- a/abr_control/interfaces/mujoco.py
+++ b/abr_control/interfaces/mujoco.py
@@ -218,11 +218,12 @@ class Mujoco(Interface):
         self.sim.step()
 
         # Update position of hand object
-        hand_xyz = self.robot_config.Tx(name="EE")
+        feedback = self.get_feedback()
+        hand_xyz = self.robot_config.Tx(name="EE", q=feedback['q'])
         self.set_mocap_xyz("hand", hand_xyz)
 
         # Update orientation of hand object
-        hand_quat = self.robot_config.quaternion(name="EE")
+        hand_quat = self.robot_config.quaternion(name="EE", q=feedback['q'])
         self.set_mocap_orientation("hand", hand_quat)
 
         if self.visualize and update_display:

--- a/abr_control/interfaces/mujoco.py
+++ b/abr_control/interfaces/mujoco.py
@@ -219,11 +219,11 @@ class Mujoco(Interface):
 
         # Update position of hand object
         feedback = self.get_feedback()
-        hand_xyz = self.robot_config.Tx(name="EE", q=feedback['q'])
+        hand_xyz = self.robot_config.Tx(name="EE", q=feedback["q"])
         self.set_mocap_xyz("hand", hand_xyz)
 
         # Update orientation of hand object
-        hand_quat = self.robot_config.quaternion(name="EE", q=feedback['q'])
+        hand_quat = self.robot_config.quaternion(name="EE", q=feedback["q"])
         self.set_mocap_orientation("hand", hand_quat)
 
         if self.visualize and update_display:

--- a/abr_control/interfaces/mujoco.py
+++ b/abr_control/interfaces/mujoco.py
@@ -297,7 +297,7 @@ class Mujoco(Interface):
         elif object_type == "geom":
             xyz = self.sim.data.get_geom_xpos(name)
         elif object_type == "site":
-            xyz = self.sim.model.get_site_xpos(name)
+            xyz = self.sim.data.get_site_xpos(name)
         else:
             raise Exception(f"get_xyz for {object_type} object type not supported")
 

--- a/docs/examples/CoppeliaSim/avoid_obstacle.py
+++ b/docs/examples/CoppeliaSim/avoid_obstacle.py
@@ -11,7 +11,6 @@ from abr_control.arms import ur5 as arm
 from abr_control.controllers import OSC, AvoidObstacles, Damping
 from abr_control.interfaces import CoppeliaSim
 
-
 # initialize our robot config
 robot_config = arm.Config()
 

--- a/docs/examples/CoppeliaSim/dynamics_adaptation_osc.py
+++ b/docs/examples/CoppeliaSim/dynamics_adaptation_osc.py
@@ -4,12 +4,12 @@ The simulation ends after 1.5 simulated seconds, and the
 trajectory of the end-effector is plotted in 3D.
 """
 import traceback
+
 import numpy as np
 
 from abr_control.arms import jaco2 as arm
 from abr_control.controllers import OSC, Damping, signals
 from abr_control.interfaces import CoppeliaSim
-
 
 # initialize our robot config for the jaco2
 robot_config = arm.Config()
@@ -48,8 +48,7 @@ target_track = []
 
 # get Jacobians to each link for calculating perturbation
 J_links = [
-    robot_config._calc_J(f"link{ii}", x=[0, 0, 0])
-    for ii in range(robot_config.N_LINKS)
+    robot_config._calc_J(f"link{ii}", x=[0, 0, 0]) for ii in range(robot_config.N_LINKS)
 ]
 
 

--- a/docs/examples/CoppeliaSim/floating.py
+++ b/docs/examples/CoppeliaSim/floating.py
@@ -6,12 +6,12 @@ is recorded and plotted when the script is exited (with ctrl-c).
 In this example, the floating controller is applied in the joint space
 """
 import traceback
+
 import numpy as np
 
 from abr_control.arms import jaco2 as arm
 from abr_control.controllers import Floating
 from abr_control.interfaces import CoppeliaSim
-
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/CoppeliaSim/joint.py
+++ b/docs/examples/CoppeliaSim/joint.py
@@ -4,6 +4,7 @@ configuration in joint space, offset from its starting position.
 The simulation simulates 1500 time steps and then plots the results.
 """
 import traceback
+
 import numpy as np
 
 # from abr_control.arms import ur5 as arm
@@ -12,7 +13,6 @@ from abr_control.arms import jaco2 as arm
 # from abr_control.arms import onejoint as arm
 from abr_control.controllers import Joint
 from abr_control.interfaces import CoppeliaSim
-
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/CoppeliaSim/orientation_control_osc.py
+++ b/docs/examples/CoppeliaSim/orientation_control_osc.py
@@ -11,7 +11,6 @@ from abr_control.controllers import OSC, Damping
 from abr_control.interfaces import CoppeliaSim
 from abr_control.utils import transformations
 
-
 # initialize our robot config
 robot_config = arm.Config()
 

--- a/docs/examples/CoppeliaSim/path_planner_bell_shaped.py
+++ b/docs/examples/CoppeliaSim/path_planner_bell_shaped.py
@@ -14,7 +14,6 @@ from abr_control.controllers import OSC, Damping, path_planners
 from abr_control.interfaces import CoppeliaSim
 from abr_control.utils import transformations
 
-
 # initialize our robot config
 robot_config = arm.Config()
 

--- a/docs/examples/CoppeliaSim/position_and_orientation_control_osc.py
+++ b/docs/examples/CoppeliaSim/position_and_orientation_control_osc.py
@@ -9,7 +9,6 @@ from abr_control.controllers import OSC, Damping
 from abr_control.interfaces import CoppeliaSim
 from abr_control.utils import transformations
 
-
 # initialize our robot config
 robot_config = arm.Config()
 

--- a/docs/examples/CoppeliaSim/position_control_osc.py
+++ b/docs/examples/CoppeliaSim/position_control_osc.py
@@ -4,6 +4,7 @@ The simulation ends after 1500 time steps, and the
 trajectory of the end-effector is plotted in 3D.
 """
 import traceback
+
 import numpy as np
 
 from abr_control.arms import ur5 as arm
@@ -12,7 +13,6 @@ from abr_control.arms import ur5 as arm
 # from abr_control.arms import onejoint as arm
 from abr_control.controllers import OSC, Damping
 from abr_control.interfaces import CoppeliaSim
-
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/CoppeliaSim/position_control_sliding.py
+++ b/docs/examples/CoppeliaSim/position_control_sliding.py
@@ -4,6 +4,7 @@ The simulation ends after 1500 time steps, and the
 trajectory of the end-effector is plotted in 3D.
 """
 import traceback
+
 import numpy as np
 
 # from abr_control.arms import ur5 as arm

--- a/docs/examples/Mujoco/dynamics_adaptation_osc.py
+++ b/docs/examples/Mujoco/dynamics_adaptation_osc.py
@@ -103,7 +103,7 @@ try:
         u += u_adapt
 
         # add an additional force for the controller to adapt to
-        extra_gravity = robot_config.g(feedback["q"]) * 2
+        extra_gravity = robot_config.g(feedback["q"]) * 4
         u += extra_gravity
 
         # add gripper forces

--- a/docs/examples/Mujoco/dynamics_adaptation_osc.py
+++ b/docs/examples/Mujoco/dynamics_adaptation_osc.py
@@ -5,11 +5,12 @@ trajectory of the end-effector is plotted in 3D.
 """
 import sys
 import traceback
-import numpy as np
-import glfw
 
-from abr_control.controllers import OSC, Damping, signals
+import glfw
+import numpy as np
+
 from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import OSC, Damping, signals
 from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
 

--- a/docs/examples/Mujoco/floating.py
+++ b/docs/examples/Mujoco/floating.py
@@ -7,13 +7,13 @@ In this example, the floating controller is applied in the joint space
 """
 import sys
 import traceback
-import numpy as np
+
 import glfw
+import numpy as np
 
-from abr_control.controllers import Floating
 from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import Floating
 from abr_control.interfaces.mujoco import Mujoco
-
 
 if len(sys.argv) > 1:
     arm_model = sys.argv[1]

--- a/docs/examples/Mujoco/geometric_arm_osc.py
+++ b/docs/examples/Mujoco/geometric_arm_osc.py
@@ -7,15 +7,15 @@ passed through sys.argv
     python threelink.py True
 """
 import sys
-import numpy as np
-import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=W0611
-import glfw
 
+import glfw
+import matplotlib.pyplot as plt
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=W0611
+
+from abr_control.arms.mujoco_config import MujocoConfig
 from abr_control.controllers import OSC
 from abr_control.interfaces.mujoco import Mujoco
-from abr_control.arms.mujoco_config import MujocoConfig
-
 
 print(
     "****************************************************************"

--- a/docs/examples/Mujoco/joint_control.py
+++ b/docs/examples/Mujoco/joint_control.py
@@ -5,13 +5,13 @@ The simulation simulates 2500 time steps and then plots the results.
 """
 import sys
 import traceback
-import numpy as np
+
 import glfw
+import numpy as np
 
 from abr_control.arms.mujoco_config import MujocoConfig as arm
-from abr_control.interfaces.mujoco import Mujoco
 from abr_control.controllers import Joint
-
+from abr_control.interfaces.mujoco import Mujoco
 
 if len(sys.argv) > 1:
     arm_model = sys.argv[1]

--- a/docs/examples/Mujoco/joint_control_balljoint.py
+++ b/docs/examples/Mujoco/joint_control_balljoint.py
@@ -1,0 +1,132 @@
+"""
+Move the jao2 Mujoco arm to a target position.
+The simulation ends after 1500 time steps, and the
+trajectory of the end-effector is plotted in 3D.
+"""
+import traceback
+import numpy as np
+import glfw
+
+import mujoco_py as mjp
+
+from abr_control.controllers import Joint
+from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.interfaces.mujoco import Mujoco
+from abr_control.utils import transformations
+from abr_control.utils.transformations import quaternion_multiply, quaternion_conjugate
+
+
+# initialize our robot config for the jaco2
+robot_config = arm("mujoco_balljoint.xml", folder=".", use_sim_state=False)
+
+# create our Mujoco interface
+interface = Mujoco(robot_config, dt=0.001)
+interface.connect()
+
+# instantiate controller
+kp = 100
+kv = np.sqrt(kp)
+ctrlr = Joint(
+    robot_config,
+    kp=kp,
+    kv=kv,
+    quaternions=[True],
+)
+
+# set up lists for tracking data
+q_track = []
+target_track = []
+error_track = []
+
+target_geom_id = interface.sim.model.geom_name2id("target")
+green = [0, 0.9, 0, 0.5]
+red = [0.9, 0, 0, 0.5]
+threshold = 0.002  # threshold distance for being within target before moving on
+
+# get the end-effector's initial position
+np.random.seed(0)
+target_quaternions = [transformations.unit_vector(
+    transformations.random_quaternion()) for ii in range(4)]
+
+target_index = 0
+target = target_quaternions[target_index]
+print(target)
+target_xyz = robot_config.Tx('EE', q=target)
+interface.set_mocap_xyz(name="target", xyz=target_xyz)
+
+try:
+    # get the end-effector's initial position
+    feedback = interface.get_feedback()
+    start = robot_config.Tx("EE", feedback["q"])
+
+    count = 0.0
+    print("\nSimulation starting...\n")
+    while 1:
+        if interface.viewer.exit:
+            glfw.destroy_window(interface.viewer.window)
+            break
+        # get joint angle and velocity feedback
+        feedback = interface.get_feedback()
+
+        # calculate the control signal
+        u = ctrlr.generate(
+            q=feedback['q'],
+            dq=feedback["dq"],
+            target=target,
+        )
+
+        # send forces into Mujoco, step the sim forward
+        interface.send_forces(u)
+
+        # track data
+        q_track.append(np.copy(feedback['q']))
+        target_track.append(np.copy(target))
+
+        # calculate the distance between quaternions
+        error = quaternion_multiply(
+            target,
+            quaternion_conjugate(feedback['q']),
+        )
+        error = 2 * np.arctan2(np.linalg.norm(error[1:]) * -np.sign(error[0]), error[0])
+        # quaternion distance for same angles can be 0 or 2*pi, so use a sine
+        # wave here so 0 and 2*np.pi = 0
+        error = np.sin(error / 2)
+        error_track.append(np.copy(error))
+
+        if abs(error) < threshold:
+            interface.sim.model.geom_rgba[target_geom_id] = green
+            count += 1
+        else:
+            count = 0
+            interface.sim.model.geom_rgba[target_geom_id] = red
+
+        if count >= 1000:
+            target_index += 1
+            target = target_quaternions[target_index % len(target_quaternions)]
+            target_xyz = robot_config.Tx('EE', q=target)
+            interface.set_mocap_xyz(name="target", xyz=target_xyz)
+            count = 0
+
+except:
+    print(traceback.format_exc())
+
+finally:
+    # stop and reset the Mujoco simulation
+    interface.disconnect()
+
+    print("Simulation terminated...")
+
+    q_track = np.array(q_track)
+    target_track = np.array(target_track)
+
+    if q_track.shape[0] > 0:
+        # plot distance from target and 3D trajectory
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d import axes3d  # pylint: disable=W0611
+
+        plt.figure(figsize=(8, 6))
+        plt.ylabel("Distance (m)")
+        plt.xlabel("Time (ms)")
+        plt.title("Distance to target")
+        plt.plot(np.array(error_track))
+        plt.show()

--- a/docs/examples/Mujoco/joint_control_balljoint.py
+++ b/docs/examples/Mujoco/joint_control_balljoint.py
@@ -4,17 +4,15 @@ The simulation ends after 1500 time steps, and the
 trajectory of the end-effector is plotted in 3D.
 """
 import traceback
-import numpy as np
+
 import glfw
+import numpy as np
 
-import mujoco_py as mjp
-
-from abr_control.controllers import Joint
 from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import Joint
 from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
-from abr_control.utils.transformations import quaternion_multiply, quaternion_conjugate
-
+from abr_control.utils.transformations import quaternion_conjugate, quaternion_multiply
 
 # initialize our robot config for the jaco2
 robot_config = arm("mujoco_balljoint.xml", folder=".", use_sim_state=False)
@@ -45,13 +43,14 @@ threshold = 0.002  # threshold distance for being within target before moving on
 
 # get the end-effector's initial position
 np.random.seed(0)
-target_quaternions = [transformations.unit_vector(
-    transformations.random_quaternion()) for ii in range(4)]
+target_quaternions = [
+    transformations.unit_vector(transformations.random_quaternion()) for ii in range(4)
+]
 
 target_index = 0
 target = target_quaternions[target_index]
 print(target)
-target_xyz = robot_config.Tx('EE', q=target)
+target_xyz = robot_config.Tx("EE", q=target)
 interface.set_mocap_xyz(name="target", xyz=target_xyz)
 
 try:
@@ -70,7 +69,7 @@ try:
 
         # calculate the control signal
         u = ctrlr.generate(
-            q=feedback['q'],
+            q=feedback["q"],
             dq=feedback["dq"],
             target=target,
         )
@@ -79,13 +78,13 @@ try:
         interface.send_forces(u)
 
         # track data
-        q_track.append(np.copy(feedback['q']))
+        q_track.append(np.copy(feedback["q"]))
         target_track.append(np.copy(target))
 
         # calculate the distance between quaternions
         error = quaternion_multiply(
             target,
-            quaternion_conjugate(feedback['q']),
+            quaternion_conjugate(feedback["q"]),
         )
         error = 2 * np.arctan2(np.linalg.norm(error[1:]) * -np.sign(error[0]), error[0])
         # quaternion distance for same angles can be 0 or 2*pi, so use a sine
@@ -103,7 +102,7 @@ try:
         if count >= 1000:
             target_index += 1
             target = target_quaternions[target_index % len(target_quaternions)]
-            target_xyz = robot_config.Tx('EE', q=target)
+            target_xyz = robot_config.Tx("EE", q=target)
             interface.set_mocap_xyz(name="target", xyz=target_xyz)
             count = 0
 

--- a/docs/examples/Mujoco/joint_control_two_balljoints.py
+++ b/docs/examples/Mujoco/joint_control_two_balljoints.py
@@ -1,0 +1,134 @@
+"""
+Move the jao2 Mujoco arm to a target position.
+The simulation ends after 1500 time steps, and the
+trajectory of the end-effector is plotted in 3D.
+"""
+import traceback
+import numpy as np
+import glfw
+
+import mujoco_py as mjp
+
+from abr_control.controllers import Joint
+from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.interfaces.mujoco import Mujoco
+from abr_control.utils import transformations
+from abr_control.utils.transformations import quaternion_multiply, quaternion_conjugate
+
+
+# initialize our robot config for the jaco2
+robot_config = arm("mujoco_two_balljoints.xml", folder=".", use_sim_state=False)
+
+# create our Mujoco interface
+interface = Mujoco(robot_config, dt=0.001)
+interface.connect()
+
+# instantiate controller
+kp = 100
+kv = np.sqrt(kp)
+ctrlr = Joint(
+    robot_config,
+    kp=kp,
+    kv=kv,
+    quaternions=[True, True],
+)
+
+# set up lists for tracking data
+q_track = []
+target_track = []
+error_track = []
+
+target_geom_id = interface.sim.model.geom_name2id("target")
+green = [0, 0.9, 0, 0.5]
+red = [0.9, 0, 0, 0.5]
+threshold = 0.002  # threshold distance for being within target before moving on
+
+# get the end-effector's initial position
+np.random.seed(0)
+target_quaternions = [np.hstack([transformations.unit_vector(
+    transformations.random_quaternion()) for jj in range(2)]) for ii in range(4)]
+
+target_index = 0
+target = target_quaternions[target_index]
+print(target)
+target_xyz = robot_config.Tx('EE', q=target)
+interface.set_mocap_xyz(name="target", xyz=target_xyz)
+
+try:
+    # get the end-effector's initial position
+    feedback = interface.get_feedback()
+    start = robot_config.Tx("EE", feedback["q"])
+
+    count = 0.0
+    print("\nSimulation starting...\n")
+    while 1:
+        if interface.viewer.exit:
+            glfw.destroy_window(interface.viewer.window)
+            break
+        # get joint angle and velocity feedback
+        feedback = interface.get_feedback()
+
+        # calculate the control signal
+        u = ctrlr.generate(
+            q=feedback['q'],
+            dq=feedback["dq"],
+            target=target,
+        )
+
+        # send forces into Mujoco, step the sim forward
+        interface.send_forces(u)
+
+        # track data
+        q_track.append(np.copy(feedback['q']))
+        target_track.append(np.copy(target))
+
+        # calculate the distance between quaternions
+        error = 0.0
+        for ii in range(2):
+            temp = quaternion_multiply(
+                target[ii*4:(ii*4)+4],
+                quaternion_conjugate(feedback['q'][ii*4:(ii*4)+4]),
+            )
+            temp = 2 * np.arctan2(np.linalg.norm(temp[1:]) * -np.sign(temp[0]), temp[0])
+            # quaternion distance for same angles can be 0 or 2*pi, so use a sine
+            # wave here so 0 and 2*np.pi = 0
+            error += np.sin(temp / 2)
+        error_track.append(np.copy(error))
+
+        if abs(error) < threshold:
+            interface.sim.model.geom_rgba[target_geom_id] = green
+            count += 1
+        else:
+            count = 0
+            interface.sim.model.geom_rgba[target_geom_id] = red
+
+        if count >= 1000:
+            target_index += 1
+            target = target_quaternions[target_index % len(target_quaternions)]
+            target_xyz = robot_config.Tx('EE', q=target)
+            interface.set_mocap_xyz(name="target", xyz=target_xyz)
+            count = 0
+
+except:
+    print(traceback.format_exc())
+
+finally:
+    # stop and reset the Mujoco simulation
+    interface.disconnect()
+
+    print("Simulation terminated...")
+
+    q_track = np.array(q_track)
+    target_track = np.array(target_track)
+
+    if q_track.shape[0] > 0:
+        # plot distance from target and 3D trajectory
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.mplot3d import axes3d  # pylint: disable=W0611
+
+        plt.figure(figsize=(8, 6))
+        plt.ylabel("Distance (m)")
+        plt.xlabel("Time (ms)")
+        plt.title("Distance to target")
+        plt.plot(np.array(error_track))
+        plt.show()

--- a/docs/examples/Mujoco/joint_control_two_balljoints.py
+++ b/docs/examples/Mujoco/joint_control_two_balljoints.py
@@ -4,17 +4,15 @@ The simulation ends after 1500 time steps, and the
 trajectory of the end-effector is plotted in 3D.
 """
 import traceback
-import numpy as np
+
 import glfw
+import numpy as np
 
-import mujoco_py as mjp
-
-from abr_control.controllers import Joint
 from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import Joint
 from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
-from abr_control.utils.transformations import quaternion_multiply, quaternion_conjugate
-
+from abr_control.utils.transformations import quaternion_conjugate, quaternion_multiply
 
 # initialize our robot config for the jaco2
 robot_config = arm("mujoco_two_balljoints.xml", folder=".", use_sim_state=False)
@@ -45,13 +43,20 @@ threshold = 0.002  # threshold distance for being within target before moving on
 
 # get the end-effector's initial position
 np.random.seed(0)
-target_quaternions = [np.hstack([transformations.unit_vector(
-    transformations.random_quaternion()) for jj in range(2)]) for ii in range(4)]
+target_quaternions = [
+    np.hstack(
+        [
+            transformations.unit_vector(transformations.random_quaternion())
+            for jj in range(2)
+        ]
+    )
+    for ii in range(4)
+]
 
 target_index = 0
 target = target_quaternions[target_index]
 print(target)
-target_xyz = robot_config.Tx('EE', q=target)
+target_xyz = robot_config.Tx("EE", q=target)
 interface.set_mocap_xyz(name="target", xyz=target_xyz)
 
 try:
@@ -70,7 +75,7 @@ try:
 
         # calculate the control signal
         u = ctrlr.generate(
-            q=feedback['q'],
+            q=feedback["q"],
             dq=feedback["dq"],
             target=target,
         )
@@ -79,15 +84,15 @@ try:
         interface.send_forces(u)
 
         # track data
-        q_track.append(np.copy(feedback['q']))
+        q_track.append(np.copy(feedback["q"]))
         target_track.append(np.copy(target))
 
         # calculate the distance between quaternions
         error = 0.0
         for ii in range(2):
             temp = quaternion_multiply(
-                target[ii*4:(ii*4)+4],
-                quaternion_conjugate(feedback['q'][ii*4:(ii*4)+4]),
+                target[ii * 4 : (ii * 4) + 4],
+                quaternion_conjugate(feedback["q"][ii * 4 : (ii * 4) + 4]),
             )
             temp = 2 * np.arctan2(np.linalg.norm(temp[1:]) * -np.sign(temp[0]), temp[0])
             # quaternion distance for same angles can be 0 or 2*pi, so use a sine
@@ -105,7 +110,7 @@ try:
         if count >= 1000:
             target_index += 1
             target = target_quaternions[target_index % len(target_quaternions)]
-            target_xyz = robot_config.Tx('EE', q=target)
+            target_xyz = robot_config.Tx("EE", q=target)
             interface.set_mocap_xyz(name="target", xyz=target_xyz)
             count = 0
 

--- a/docs/examples/Mujoco/mujoco_two_balljoints.xml
+++ b/docs/examples/Mujoco/mujoco_two_balljoints.xml
@@ -1,4 +1,4 @@
-<mujoco model="balljoint">
+<mujoco model="two_balljoints">
     <compiler angle="radian"/>
     <contact>
         <exclude body1="base_link" body2="link0"/>
@@ -21,7 +21,12 @@
                 <joint name='joint0' type="ball" pos="0 0 0"/>
                 <geom type="capsule" pos="0 0 .5" size=".1 .5" euler="0 0 0" rgba=".7 .7 .7 .5"/>
 
-                <body name="EE" pos="0 0 1"/>
+                <body name="link1" pos="0 0 1">
+                    <joint name='joint1' type="ball" pos="0 0 0"/>
+                    <geom type="capsule" pos="0 0 .5" size=".1 .5" euler="0 0 0" rgba=".7 .7 .7 .5"/>
+
+                    <body name="EE" pos="0 0 1"/>
+                </body>
             </body>
         </body>
     </worldbody>
@@ -30,6 +35,10 @@
         <motor name="joint0_motor0" joint="joint0" gear="1 0 0 0 0 0"/>
         <motor name="joint0_motor1" joint="joint0" gear="0 1 0 0 0 0"/>
         <motor name="joint0_motor2" joint="joint0" gear="0 0 1 0 0 0"/>
+
+        <motor name="joint1_motor0" joint="joint1" gear="1 0 0 0 0 0"/>
+        <motor name="joint1_motor1" joint="joint1" gear="0 1 0 0 0 0"/>
+        <motor name="joint1_motor2" joint="joint1" gear="0 0 1 0 0 0"/>
     </actuator>
 </mujoco>
 

--- a/docs/examples/Mujoco/orientation_control_osc.py
+++ b/docs/examples/Mujoco/orientation_control_osc.py
@@ -45,7 +45,7 @@ try:
     print("\nSimulation starting...\n")
     cnt = 0
     while 1:
-        if cnt % 500 == 0:
+        if cnt % 1000 == 0:
             # generate a random target orientation
             rand_orient = transformations.random_quaternion()
             print("New target orientation: ", rand_orient)

--- a/docs/examples/Mujoco/orientation_control_osc.py
+++ b/docs/examples/Mujoco/orientation_control_osc.py
@@ -3,14 +3,14 @@ Running operational space control using Mujoco. The controller will
 move the end-effector to the target object's orientation.
 """
 import sys
-import numpy as np
-import glfw
 
-from abr_control.controllers import OSC, Damping
+import glfw
+import numpy as np
+
 from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import OSC, Damping
 from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
-
 
 if len(sys.argv) > 1:
     arm_model = sys.argv[1]

--- a/docs/examples/Mujoco/path_planning_inverse_kinematics.py
+++ b/docs/examples/Mujoco/path_planning_inverse_kinematics.py
@@ -4,12 +4,12 @@ for a Mujoco simulation. The path planning system will generate
 a trajectory in joint space that moves the end effector in a straight line
 to the target, which changes every n time steps.
 """
-import numpy as np
 import glfw
+import numpy as np
 
-from abr_control.interfaces.mujoco import Mujoco
 from abr_control.arms.mujoco_config import MujocoConfig as arm
 from abr_control.controllers import path_planners
+from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
 
 # initialize our robot config for the jaco2

--- a/docs/examples/Mujoco/position_and_orientation_control_osc.py
+++ b/docs/examples/Mujoco/position_and_orientation_control_osc.py
@@ -6,14 +6,14 @@ The cartesian direction being controlled is set in the first three booleans
 of the ctrlr_dof parameter
 """
 import sys
-import numpy as np
+
 import glfw
+import numpy as np
 
 from abr_control.arms.mujoco_config import MujocoConfig as arm
-from abr_control.interfaces.mujoco import Mujoco
 from abr_control.controllers import OSC, Damping
+from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
-
 
 if len(sys.argv) > 1:
     arm_model = sys.argv[1]

--- a/docs/examples/Mujoco/position_and_orientation_path_planner.py
+++ b/docs/examples/Mujoco/position_and_orientation_path_planner.py
@@ -8,14 +8,14 @@ and applies a second order path planner to both position and orientation targets
 After termination the script will plot results
 """
 import sys
-import numpy as np
-import glfw
 
-from abr_control.controllers import OSC, Damping, path_planners
+import glfw
+import numpy as np
+
 from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import OSC, Damping, path_planners
 from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
-
 
 # initialize our robot config
 if len(sys.argv) > 1:

--- a/docs/examples/Mujoco/position_control_osc.py
+++ b/docs/examples/Mujoco/position_control_osc.py
@@ -5,14 +5,14 @@ trajectory of the end-effector is plotted in 3D.
 """
 import sys
 import traceback
-import numpy as np
-import glfw
 
-from abr_control.controllers import OSC, Damping
+import glfw
+import numpy as np
+
 from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import OSC, Damping
 from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
-
 
 if len(sys.argv) > 1:
     arm_model = sys.argv[1]

--- a/docs/examples/Mujoco/position_control_osc_balljoint.py
+++ b/docs/examples/Mujoco/position_control_osc_balljoint.py
@@ -4,14 +4,14 @@ The simulation ends after 1500 time steps, and the
 trajectory of the end-effector is plotted in 3D.
 """
 import traceback
-import numpy as np
-import glfw
 
-from abr_control.controllers import OSC
+import glfw
+import numpy as np
+
 from abr_control.arms.mujoco_config import MujocoConfig as arm
+from abr_control.controllers import OSC
 from abr_control.interfaces.mujoco import Mujoco
 from abr_control.utils import transformations
-
 
 # initialize our robot config for the jaco2
 robot_config = arm("mujoco_balljoint.xml", folder=".")

--- a/docs/examples/Mujoco/threejoint_path_planner.py
+++ b/docs/examples/Mujoco/threejoint_path_planner.py
@@ -9,14 +9,15 @@ passed through sys.argv
 
 import sys
 import timeit
-import numpy as np
-import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=W0611
-import glfw
 
+import glfw
+import matplotlib.pyplot as plt
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=W0611
+
+from abr_control.arms.mujoco_config import MujocoConfig
 from abr_control.controllers import OSC, path_planners
 from abr_control.interfaces.mujoco import Mujoco
-from abr_control.arms.mujoco_config import MujocoConfig
 
 if len(sys.argv) > 1:
     use_wall_clock = True

--- a/docs/examples/PyGame/avoid_joint_limits.py
+++ b/docs/examples/PyGame/avoid_joint_limits.py
@@ -6,11 +6,10 @@ The target location can be moved by clicking on the background.
 import numpy as np
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, AvoidJointLimits, Damping
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, AvoidJointLimits, Damping
-
 
 print("\nClick to move the target.\n")
 

--- a/docs/examples/PyGame/avoid_obstacles.py
+++ b/docs/examples/PyGame/avoid_obstacles.py
@@ -6,9 +6,8 @@ by clicking on the background.
 import numpy as np
 
 from abr_control.arms import threejoint as arm
-from abr_control.interfaces.pygame import PyGame
 from abr_control.controllers import OSC, AvoidObstacles, Damping
-
+from abr_control.interfaces.pygame import PyGame
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/PyGame/dynamics_adaptation_osc.py
+++ b/docs/examples/PyGame/dynamics_adaptation_osc.py
@@ -6,17 +6,17 @@ can be by clicking inside the display.
 To turn adaptation on or off, press the spacebar.
 """
 from os import environ
+
 import numpy as np
 
 environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 import pygame
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping, signals
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, Damping, signals
-
 
 # initialize our robot config
 robot_config = arm.Config()
@@ -68,8 +68,7 @@ interface.set_target(target_xyz)
 
 # get Jacobians to each link for calculating perturbation
 J_links = [
-    robot_config._calc_J(f"link{ii}", x=[0, 0, 0])
-    for ii in range(robot_config.N_LINKS)
+    robot_config._calc_J(f"link{ii}", x=[0, 0, 0]) for ii in range(robot_config.N_LINKS)
 ]
 
 

--- a/docs/examples/PyGame/dynamics_adaptation_sliding.py
+++ b/docs/examples/PyGame/dynamics_adaptation_sliding.py
@@ -6,17 +6,17 @@ can be by clicking inside the display.
 To turn adaptation on or off, press the spacebar.
 """
 from os import environ
+
 import numpy as np
 
 environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 import pygame
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import Sliding, signals
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import Sliding, signals
-
 
 # initialize our robot config
 robot_config = arm.Config()
@@ -59,8 +59,7 @@ interface.set_target(target_xyz)
 
 # get Jacobians to each link for calculating perturbation
 J_links = [
-    robot_config._calc_J(f"link{ii}", x=[0, 0, 0])
-    for ii in range(robot_config.N_LINKS)
+    robot_config._calc_J(f"link{ii}", x=[0, 0, 0]) for ii in range(robot_config.N_LINKS)
 ]
 
 

--- a/docs/examples/PyGame/integrated_error_osc.py
+++ b/docs/examples/PyGame/integrated_error_osc.py
@@ -6,16 +6,16 @@ can be by clicking inside the display.
 To turn adaptation on or off, press the spacebar.
 """
 from os import environ
+
 import numpy as np
 
 environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, Damping
-
 
 # initialize our robot config
 robot_config = arm.Config()
@@ -52,8 +52,7 @@ interface.set_target(target_xyz)
 
 # get Jacobians to each link for calculating perturbation
 J_links = [
-    robot_config._calc_J(f"link{ii}", x=[0, 0, 0])
-    for ii in range(robot_config.N_LINKS)
+    robot_config._calc_J(f"link{ii}", x=[0, 0, 0]) for ii in range(robot_config.N_LINKS)
 ]
 
 

--- a/docs/examples/PyGame/orientation_control_osc.py
+++ b/docs/examples/PyGame/orientation_control_osc.py
@@ -4,18 +4,18 @@ move the end-effector to a target orientation, which can be changed by
 pressing the left/right arrow keys.
 """
 from os import environ
+
 import numpy as np
 
 environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 import pygame
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
 from abr_control.utils import transformations
-from abr_control.controllers import OSC, Damping
-
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/PyGame/path_planning_arc.py
+++ b/docs/examples/PyGame/path_planning_arc.py
@@ -20,11 +20,10 @@ import timeit
 import numpy as np
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping, path_planners
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, Damping, path_planners
-
 
 # if set to True, the simulation will plan the path to
 # last for 1 second of real-time

--- a/docs/examples/PyGame/path_planning_constant_velocity.py
+++ b/docs/examples/PyGame/path_planning_constant_velocity.py
@@ -4,16 +4,14 @@ using the PyGame display. The path planner system will generate a
 trajectory for the controller to follow, moving the end-effector in a
 straight line to the target, which changes every n time steps.
 """
+import matplotlib.pyplot as plt
 import numpy as np
 
-import matplotlib.pyplot as plt
-
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping, path_planners
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, Damping, path_planners
-
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/PyGame/path_planning_dmps.py
+++ b/docs/examples/PyGame/path_planning_dmps.py
@@ -14,11 +14,10 @@ except ImportError:
     print("\npydmps library required, see " + "https://github.com/studywolf/pydmps\n")
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, Damping
-
 
 # create a dmp that traces a circle
 x = np.linspace(0, np.pi * 2, 100)

--- a/docs/examples/PyGame/path_planning_inverse_kinematics.py
+++ b/docs/examples/PyGame/path_planning_inverse_kinematics.py
@@ -7,12 +7,11 @@ to the target, which changes every n time steps.
 import numpy as np
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import Joint, path_planners
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import Joint, path_planners
 from abr_control.utils import transformations
-
 
 # change this flag to False to use position control
 use_force_control = True

--- a/docs/examples/PyGame/path_planning_linear_filter.py
+++ b/docs/examples/PyGame/path_planning_linear_filter.py
@@ -16,11 +16,10 @@ import timeit
 import numpy as np
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping, path_planners
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, Damping, path_planners
-
 
 # if set to True, the simulation will plan the path to
 # last for 1 second of real-time

--- a/docs/examples/PyGame/path_planning_second_order.py
+++ b/docs/examples/PyGame/path_planning_second_order.py
@@ -12,12 +12,12 @@ There is largely no benefit to using wall clock time in simulation, but for
 implementation on real robots it can be a very helpful function.
 """
 import timeit
+
 import numpy as np
 
 from abr_control.arms import threejoint as arm
-from abr_control.interfaces.pygame import PyGame
 from abr_control.controllers import OSC, Damping, path_planners
-
+from abr_control.interfaces.pygame import PyGame
 
 # if set to True, the simulation will plan the path to
 # last for 1 second of real-time

--- a/docs/examples/PyGame/path_planning_second_order_filter.py
+++ b/docs/examples/PyGame/path_planning_second_order_filter.py
@@ -16,11 +16,10 @@ import timeit
 import numpy as np
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping, path_planners
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, Damping, path_planners
-
 
 # if set to True, the simulation will plan the path to
 # last for 1 second of real-time

--- a/docs/examples/PyGame/position_and_orientation_control_osc.py
+++ b/docs/examples/PyGame/position_and_orientation_control_osc.py
@@ -5,18 +5,18 @@ the z axis. The (x, y) target can be changed by clicking on the background,
 and the target orientation can be changed with the left/right arrow keys.
 """
 from os import environ
+
 import numpy as np
 
 environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 import pygame
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
 from abr_control.utils import transformations
-from abr_control.controllers import OSC, Damping
-
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/PyGame/position_control_osc.py
+++ b/docs/examples/PyGame/position_control_osc.py
@@ -6,11 +6,10 @@ clicking on the background.
 import numpy as np
 
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import OSC, Damping, RestingConfig
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import OSC, Damping, RestingConfig
-
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/PyGame/position_control_sliding.py
+++ b/docs/examples/PyGame/position_control_sliding.py
@@ -4,11 +4,10 @@ move the end-effector to the target, which can be moved by
 clicking on the background.
 """
 from abr_control.arms import threejoint as arm
+from abr_control.controllers import Sliding
 
 # from abr_control.arms import twojoint as arm
 from abr_control.interfaces.pygame import PyGame
-from abr_control.controllers import Sliding
-
 
 # initialize our robot config
 robot_config = arm.Config()

--- a/docs/examples/timing_plots.py
+++ b/docs/examples/timing_plots.py
@@ -3,7 +3,7 @@ import timeit
 import matplotlib.pyplot as plt
 import numpy as np
 
-from abr_control.arms import twojoint, ur5, jaco2
+from abr_control.arms import jaco2, twojoint, ur5
 from abr_control.controllers import OSC
 
 


### PR DESCRIPTION
Adds joint space control of ball joints into the Joint controller, so that it properly handles computing distance and difference between quaternions and generating angular forces to apply. Also added some examples to test it in the Mujoco examples folder. 

Currently requires users passing in a boolean list identifying which joints are ball joints to the Joint controller, e.g., `quaternions=[True, True, False]`. Should be able to automate this discovery so the user doesn't have to specify.

Also makes RestingConfig a subclass of Joint controller, and fixes a bug in DynamicsAdaptation where if the user only specified mean or scale neither were applied.