### PR TITLE
Bug fixes: dynadapt, rest config, path planner

### DIFF
--- a/abr_control/controllers/resting_config.py
+++ b/abr_control/controllers/resting_config.py
@@ -20,6 +20,15 @@ class RestingConfig(Joint):
 
         self.rest_angles = np.asarray(rest_angles)
         self.rest_indices = [val is not None for val in rest_angles]
+        self.q_tilde = self.q_tilde_angle
+
+    def q_tilde_angle(self, q, target):
+        # distance / direction
+        q_tilde = np.zeros(len(q))
+        q_tilde[self.rest_indices] = (
+            self.rest_angles[self.rest_indices] - q[self.rest_indices] + np.pi
+        ) % (np.pi * 2) - np.pi
+        return q_tilde
 
     def generate(self, q, dq):
         """Generates the control signal

--- a/abr_control/controllers/signals/dynamics_adaptation.py
+++ b/abr_control/controllers/signals/dynamics_adaptation.py
@@ -67,8 +67,10 @@ class DynamicsAdaptation:
         tau_training=0.012,
         tau_output=0.2,
         dt=0.001,
-        **kwargs
+        **ens_kwargs
     ):
+        self.dt = dt
+
         # set up means and variances to be same dimensionality as original input signal
         self.variances = (
             np.ones(n_input) if variances is None else np.asarray(variances)
@@ -163,9 +165,8 @@ class DynamicsAdaptation:
                         n_neurons=self.n_neurons,
                         dimensions=n_input,
                         intercepts=intercepts[ii],
-                        radius=np.sqrt(n_input),
                         encoders=encoders[ii],
-                        **kwargs,
+                        **ens_kwargs,
                     )
                 )
 
@@ -212,11 +213,11 @@ class DynamicsAdaptation:
             input_signal = self.scale_inputs(input_signal)
 
         # store local copies to feed in to the adaptive population
-        self.input_signal = input_signal
+        self.input_signal = np.squeeze(input_signal)
         self.training_signal = training_signal
 
         # run the simulation t generate the adaptive signal
-        self.sim.run(time_in_seconds=0.001, progress_bar=False)
+        self.sim.run(time_in_seconds=self.dt, progress_bar=False)
 
         return self.output
 

--- a/docs/examples/Mujoco/force_osc_xyz_dynamics_adaptation.py
+++ b/docs/examples/Mujoco/force_osc_xyz_dynamics_adaptation.py
@@ -48,6 +48,7 @@ adapt = signals.DynamicsAdaptation(
     means=[0.12, 2.14, 1.87, 4.32, 0.59, 0.12, -0.38, -0.42, -0.29, 0.36],
     variances=[0.08, 0.6, 0.7, 0.3, 0.6, 0.08, 1.4, 1.6, 0.7, 1.2],
     spherical=True,
+    **{'radius': 1}
 )
 
 target_geom_id = interface.sim.model.geom_name2id("target")

--- a/docs/examples/PyGame/force_osc_xy.py
+++ b/docs/examples/PyGame/force_osc_xy.py
@@ -20,7 +20,7 @@ arm_sim = arm.ArmSim(robot_config)
 damping = Damping(robot_config, kv=10)
 # keep the arm near a default configuration
 resting_config = RestingConfig(
-    robot_config, kp=50, kv=np.sqrt(50), rest_angles=[np.pi / 4, np.pi / 4, None]
+    robot_config, kp=50, kv=np.sqrt(50), rest_angles=[np.pi / 4, np.pi, None]
 )
 
 # create an operational space controller
@@ -28,7 +28,7 @@ ctrlr = OSC(
     robot_config,
     kp=20,
     use_C=True,
-    null_controllers=[damping],
+    null_controllers=[damping, resting_config],
     # control (x, y) out of [x, y, z, alpha, beta, gamma]
     ctrlr_dof=[True, True, False, False, False, False],
 )

--- a/docs/examples/path_planning/linear_position_gauss_velocity.py
+++ b/docs/examples/path_planning/linear_position_gauss_velocity.py
@@ -13,7 +13,7 @@ path.generate_path(
     target_position=np.array([5, 3, -2]),
     start_orientation=np.array([0, 0, 0]),
     target_orientation=np.array([0, 0, 3.14]),
-    max_velocity=2,
+    max_velocity=20,
     start_velocity=0,
     target_velocity=0,
     plot=True,

--- a/docs/examples/path_planning/linear_position_gauss_velocity_successive_target.py
+++ b/docs/examples/path_planning/linear_position_gauss_velocity_successive_target.py
@@ -9,40 +9,82 @@ from abr_control.controllers.path_planners import PathPlanner
 from abr_control.controllers.path_planners.position_profiles import Linear
 from abr_control.controllers.path_planners.velocity_profiles import Gaussian
 
-n_targets = 5
-
+n_targets = 3
+dt = 0.001
+np.random.seed(12)
 Pprof = Linear()
-Vprof = Gaussian(dt=0.001, acceleration=1)
+Vprof = Gaussian(dt=dt, acceleration=1)
 
-path_planner = PathPlanner(pos_profile=Pprof, vel_profile=Vprof)
-start = np.zeros(3)
-targets = np.random.uniform(low=-5, high=5, size=(n_targets, 3))
+path_planner = PathPlanner(pos_profile=Pprof, vel_profile=Vprof, verbose=True)
+start = np.zeros(6)
+targets = np.random.uniform(low=-15, high=15, size=(n_targets, 3))
+yaws = np.random.uniform(low=-3.14, high=3.14, size=n_targets)
 
 for ii, target in enumerate(targets):
+    # print('YAWS: ', yaws)
     if ii == 0:
-        start_position = start
+        start_position = start[:3]
+        start_orientation = start[3:]
     else:
         start_position = targets[ii - 1]
+        start_orientation = [0, 0, yaws[ii-1]]
 
     path = path_planner.generate_path(
-        start_position=start_position, target_position=target, max_velocity=2
+        start_position=start_position,
+        target_position=target,
+        max_velocity=6,
+        start_orientation=start_orientation,
+        target_orientation=[0, 0, yaws[ii]],
+        # plot=True
     )
 
     if ii == 0:
         position_path = path[:, :3]
         velocity_path = path[:, 3:6]
+        orientation_path = path[:, 6:9]
+        angvel_path = path[:, 9:]
     elif ii > 0:
         position_path = np.vstack((position_path, path[:, :3]))
         velocity_path = np.vstack((velocity_path, path[:, 3:6]))
+        orientation_path = np.vstack((orientation_path, path[:, 6:9]))
+        angvel_path = np.vstack((angvel_path, path[:, 9:]))
+    # print('START: ', start_orientation)
+    # print('TARGET: ', yaws[ii])
+    # print(path[:, 8])
 
-plt.figure()
-plt.subplot(211)
-plt.title("Position Path")
-plt.plot(position_path)
+times = np.arange(0, position_path.shape[0]*dt, dt)
 
-plt.subplot(212)
-plt.title("Velocity Path")
-plt.plot(velocity_path)
-plt.plot(np.linalg.norm(velocity_path, axis=1))
-plt.legend(["dx", "dy", "dz", "norm"])
+plt.rcParams.update({'font.size': 16})
+plt.figure(figsize=(15,6))
+plt.suptitle('Reference Trajectory')
+plt.subplot(221)
+# plt.title("Position Path")
+plt.plot(times, position_path)
+plt.legend(["x", "y", "z"], loc=1)
+plt.ylabel('Position [m]')
+plt.xlabel('Time [sec]')
+
+plt.subplot(222)
+# plt.title("Velocity Path")
+plt.plot(times, velocity_path)
+plt.plot(times, np.linalg.norm(velocity_path, axis=1))
+plt.legend(["dx", "dy", "dz", "norm"], loc=1)
+plt.ylabel('Velocity [m/s]')
+plt.xlabel('Time [sec]')
+
+plt.subplot(223)
+# plt.title("Orientation Path")
+plt.plot(times, orientation_path)
+plt.legend(["pitch", "roll", "yaw"], loc=1)
+plt.ylabel('Orientation [rad]')
+plt.xlabel('Time [sec]')
+
+plt.subplot(224)
+# plt.title("Angular Velocity Path")
+plt.plot(times, angvel_path)
+plt.legend(["dpitch", "droll", "dyaw"], loc=1)
+plt.ylabel('Angular Velocity [rad/s]')
+plt.xlabel('Time [sec]')
+
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
resting_config.py
- updated example to use resting config, previously was instantiated but damping null controller was being passed in to osc. If resting was passed in it would throw errors
- made a q_tilde function in resting config to account for None joints

dynamics_adaptation.py
- updated sim step to use dt passed on init, before was hardcoded to 1ms
- removed hardcoded radius in Ens instantiation, now using **ens_kwargs
- renamed kwargs -> ens_kwargs for clarity

path_planner.py
- before if the max_v was so large that it was not reachable given the acceleration of the velocity profile and the distance to cover, the starting and ending velocity profile would be scaled by the difference in distance to cover and distance covered in those vel profiles. This would lead to a constant step size for all paths where max_v could not be reached, which would lead to very slow paths for short reaches
- updated to catch this and lower max_v until the maximum attainable velocity is reached