### PR TITLE
fixed type error that originated from pygame.Surface() 

### DIFF
--- a/abr_control/interfaces/pygame.py
+++ b/abr_control/interfaces/pygame.py
@@ -83,7 +83,7 @@ class PyGame:
         # create transparent arm lines
         self.lines_base = []
         for ii, L in enumerate(self.L):
-            self.lines_base.append(pygame.Surface((L, line_width), pygame.SRCALPHA, 32))
+            self.lines_base.append(pygame.Surface((int(L), line_width), pygame.SRCALPHA, 32))
             # color in transparent arm lines
             self.lines_base[ii].fill(line_color)
 


### PR DESCRIPTION
when running   "abr_control/examples/PyGame/avoid_obstacles.py"  a type error is raised caused by 'pygame.Surface()'. It is fixed by casting the input param to int.
   

Error:
_Traceback (most recent call last):
  File "/home/steffen/workspace_common/abr_control/examples/PyGame/avoid_obstacles.py", line 37, in <module>
    interface = PyGame(robot_config, arm_sim, on_click=on_click)
  File "/home/steffen/workspace_common/abr_control/abr_control/interfaces/pygame.py", line 86, in __init__
    self.lines_base.append(pygame.Surface((L, line_width), pygame.SRCALPHA, 32))
ValueError: size needs to be (number width, number height)_
